### PR TITLE
Enable WixUtilExtension by default.

### DIFF
--- a/src/create.rs
+++ b/src/create.rs
@@ -267,6 +267,8 @@ impl Execution {
         }
         compiler.arg(format!("-dVersion={}", version))
             .arg(format!("-dPlatform={}", platform))
+            .arg("-ext")
+            .arg("WixUtilExtension")
             .arg("-o")
             .arg(&source_wixobj)
             .arg(&source_wxs);
@@ -305,6 +307,8 @@ impl Execution {
         }
         linker.arg("-ext")
             .arg("WixUIExtension")
+            .arg("-ext")
+            .arg("WixUtilExtension")
             .arg(format!("-cultures:{}", self.culture))
             .arg(&source_wixobj)
             .arg("-out")


### PR DESCRIPTION
Hi @volks73,

Thanks for making this great crate. I need to register a Windows `EventSource` in my installer for which I need to use the Wix UtilExtension.

This patch simply always enables the Wix UtilExtension via command line switches to `candle` and `light`. I'm not sure how harmful this for people who don't need it but since the UtilExtension is included in the default Wix Toolkit install I believe it shouldn't cause errors.