### PR TITLE
Use cargo-metadata instead of parsing TOMLs by hand

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,12 +27,15 @@ log = "0.4"
 maplit = "1"
 mustache = "0.9"
 regex = "1"
-semver = "0.9"
+semver = "0.10"
 sxd-document = "0.3"
 sxd-xpath = "0.4"
 termcolor = "1"
+# TODO: Remove
 toml = "0.5"
 uuid = { version = "0.8", features = ["v4"] }
+cargo_metadata = "0.11"
+serde_json = "1.0"
 
 [dev-dependencies]
 assert_fs = "1.0"

--- a/src/clean.rs
+++ b/src/clean.rs
@@ -15,13 +15,9 @@
 //! The implementation for the `clean` command. This command is focused on
 //! cleaning up build output, similar to the `cargo clean` subcommand.
 
-use crate::Error;
 use crate::Result;
-use crate::CARGO_MANIFEST_FILE;
 use crate::WIX;
 
-use std::env;
-use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -121,6 +117,7 @@ mod tests {
 
         use super::*;
         use std::fs::File;
+        use std::env;
 
         #[test]
         fn target_wix_works() {

--- a/src/clean.rs
+++ b/src/clean.rs
@@ -116,13 +116,15 @@ mod tests {
         extern crate assert_fs;
 
         use super::*;
-        use std::fs::File;
         use std::env;
+        use std::fs::File;
 
         #[test]
         fn target_wix_works() {
             let mut cwd = env::current_dir().expect("Current Working Directory");
-            let actual = Execution::default().target_wix(&cwd.join("target")).unwrap();
+            let actual = Execution::default()
+                .target_wix(&cwd.join("target"))
+                .unwrap();
             cwd.push("target");
             cwd.push(WIX);
             assert_eq!(actual, cwd);

--- a/src/clean.rs
+++ b/src/clean.rs
@@ -124,14 +124,17 @@ mod tests {
 
         #[test]
         fn target_wix_works() {
-            let actual = Execution::default().target_wix(Path::new("target")).unwrap();
             let mut cwd = env::current_dir().expect("Current Working Directory");
+            let actual = Execution::default().target_wix(&cwd.join("target")).unwrap();
             cwd.push("target");
             cwd.push(WIX);
             assert_eq!(actual, cwd);
         }
 
+        // This will blow up in run(), when trying to acquire the manifest.
+        // Target_wix can't fail anymore.
         #[test]
+        #[ignore]
         fn target_wix_with_nonexistent_manifest_fails() {
             let result = Builder::new()
                 .input(Some("C:\\Cargo.toml"))
@@ -144,12 +147,13 @@ mod tests {
         fn target_wix_with_existing_cargo_toml_works() {
             let temp_dir = assert_fs::TempDir::new().unwrap();
             let cargo_toml_path = temp_dir.path().join("Cargo.toml");
-            let expected = temp_dir.path().join("target").join(WIX);
+            let target = temp_dir.path().join("target");
+            let expected = target.join(WIX);
             let _non_cargo_toml_handle = File::create(&cargo_toml_path).expect("Create file");
             let actual = Builder::new()
                 .input(cargo_toml_path.to_str())
                 .build()
-                .target_wix(&expected)
+                .target_wix(&target)
                 .unwrap();
             assert_eq!(actual, expected);
         }

--- a/src/clean.rs
+++ b/src/clean.rs
@@ -75,6 +75,7 @@ impl Execution {
     pub fn run(self) -> Result<()> {
         debug!("input = {:?}", self.input);
         let manifest = super::manifest(self.input.as_ref())?;
+        debug!("target_directory = {:?}", manifest.target_directory);
         let target_wix = self.target_wix(&manifest.target_directory)?;
         debug!("target_wix = {:?}", target_wix);
         if target_wix.exists() {

--- a/src/create.rs
+++ b/src/create.rs
@@ -875,7 +875,7 @@ impl Execution {
         // for PathBuf, but it was unexpected and kind of annoying because I am
         // not sure how to add a trailing slash in a cross-platform way with
         // PathBuf, not that cargo-wix needs to be cross-platform.
-        let dst = target_directory.join("");
+        let dst = target_directory.join("wix\\");
         Ok(dst)
     }
 

--- a/src/create.rs
+++ b/src/create.rs
@@ -41,12 +41,12 @@ use semver::Version;
 
 use std::convert::TryFrom;
 use std::env;
+use std::ffi::OsString;
 use std::fmt;
 use std::io::{ErrorKind, Read};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::str::FromStr;
-use std::ffi::OsString;
 
 use cargo_metadata::Package;
 use serde_json::Value;
@@ -1591,7 +1591,7 @@ mod tests {
                     false,
                     &InstallerKind::default(),
                     &serde_json::from_str(PKG_META_WIX).unwrap(),
-                    Path::new("target/")
+                    Path::new("target/"),
                 )
                 .unwrap();
             assert_eq!(output, PathBuf::from("target/wix/test.msi"));

--- a/src/create.rs
+++ b/src/create.rs
@@ -877,7 +877,7 @@ impl Execution {
         // for PathBuf, but it was unexpected and kind of annoying because I am
         // not sure how to add a trailing slash in a cross-platform way with
         // PathBuf, not that cargo-wix needs to be cross-platform.
-        let dst = target_directory.join("wix\\");
+        let dst = target_directory.join(WIX).join("");
         Ok(dst)
     }
 

--- a/src/create.rs
+++ b/src/create.rs
@@ -372,6 +372,7 @@ impl Execution {
         let manifest_path = super::cargo_toml_file(self.input.as_ref())?;
         debug!("manifest_path = {:?}", manifest_path);
         let manifest = super::manifest(self.input.as_ref())?;
+        debug!("target_directory = {:?}", manifest.target_directory);
         let package = super::package(&manifest, self.package.as_deref())?;
         let metadata = package.metadata.clone();
         let name = self.name(&package)?;

--- a/src/create.rs
+++ b/src/create.rs
@@ -368,6 +368,7 @@ impl Execution {
         debug!("self.name = {:?}", self.name);
         debug!("self.no_build = {:?}", self.no_build);
         debug!("self.output = {:?}", self.output);
+        debug!("self.package = {:?}", self.package);
         debug!("self.version = {:?}", self.version);
         let manifest_path = super::cargo_toml_file(self.input.as_ref())?;
         debug!("manifest_path = {:?}", manifest_path);

--- a/src/create.rs
+++ b/src/create.rs
@@ -48,7 +48,7 @@ use std::process::{Command, Stdio};
 use std::str::FromStr;
 use std::ffi::OsString;
 
-use cargo_metadata::{Metadata, Package, MetadataCommand};
+use cargo_metadata::Package;
 use serde_json::Value;
 
 /// A builder for running the `cargo wix` subcommand.
@@ -806,6 +806,7 @@ impl Execution {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn installer_destination(
         &self,
         name: &str,

--- a/src/create.rs
+++ b/src/create.rs
@@ -854,7 +854,7 @@ impl Execution {
             }
         } else {
             trace!("Using the current working directory (CWD) to build the WiX object files destination");
-            Ok(target_directory.to_owned())
+            Ok(target_directory.join(WIX).join(filename))
         }
     }
 

--- a/src/create.rs
+++ b/src/create.rs
@@ -861,7 +861,7 @@ impl Execution {
                 Ok(path.to_owned())
             }
         } else {
-            trace!("Using the current working directory (CWD) to build the WiX object files destination");
+            trace!("Using the package's manifest (Cargo.toml) file path to specify the MSI destination");
             Ok(target_directory.join(WIX).join(filename))
         }
     }

--- a/src/create.rs
+++ b/src/create.rs
@@ -48,11 +48,13 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::str::FromStr;
 
-use toml::Value;
+use cargo_metadata::{Metadata, Package, MetadataCommand};
+use serde_json::Value;
 
 /// A builder for running the `cargo wix` subcommand.
 #[derive(Debug, Clone)]
 pub struct Builder<'a> {
+    package: Option<&'a str>,
     bin_path: Option<&'a str>,
     capture_output: bool,
     compiler_args: Option<Vec<&'a str>>,
@@ -73,6 +75,7 @@ impl<'a> Builder<'a> {
     /// Creates a new `Builder` instance.
     pub fn new() -> Self {
         Builder {
+            package: None,
             bin_path: None,
             capture_output: true,
             compiler_args: None,
@@ -88,6 +91,12 @@ impl<'a> Builder<'a> {
             output: None,
             version: None,
         }
+    }
+
+    /// Sets the package on which to operate during this build
+    pub fn package(&mut self, p: Option<&'a str>) -> &mut Self {
+        self.package = p;
+        self
     }
 
     /// Sets the path to the WiX Toolset's `bin` folder.
@@ -287,6 +296,7 @@ impl<'a> Builder<'a> {
     /// Builds a context for creating, or building, the installer.
     pub fn build(&mut self) -> Execution {
         Execution {
+            package: self.package.map(String::from),
             bin_path: self.bin_path.map(PathBuf::from),
             capture_output: self.capture_output,
             compiler_args: self
@@ -323,6 +333,7 @@ impl<'a> Default for Builder<'a> {
 /// A context for creating, or building, an installer.
 #[derive(Debug)]
 pub struct Execution {
+    package: Option<String>,
     bin_path: Option<PathBuf>,
     capture_output: bool,
     compiler_args: Option<Vec<String>>,
@@ -343,6 +354,7 @@ impl Execution {
     /// Creates, or builds, an installer within a built context.
     #[allow(clippy::cognitive_complexity)]
     pub fn run(self) -> Result<()> {
+        debug!("self.package = {:?}", self.package);
         debug!("self.bin_path = {:?}", self.bin_path);
         debug!("self.capture_output = {:?}", self.capture_output);
         debug!("self.compiler_args = {:?}", self.compiler_args);
@@ -360,29 +372,31 @@ impl Execution {
         let manifest_path = super::cargo_toml_file(self.input.as_ref())?;
         debug!("manifest_path = {:?}", manifest_path);
         let manifest = super::manifest(self.input.as_ref())?;
-        let name = self.name(&manifest)?;
+        let package = super::package(&manifest, self.package.as_deref())?;
+        let metadata = package.metadata.clone();
+        let name = self.name(&package)?;
         debug!("name = {:?}", name);
-        let version = self.version(&manifest)?;
+        let version = self.version(&package)?;
         debug!("version = {:?}", version);
-        let compiler_args = self.compiler_args(&manifest);
+        let compiler_args = self.compiler_args(&metadata);
         debug!("compiler_args = {:?}", compiler_args);
-        let culture = self.culture(&manifest)?;
+        let culture = self.culture(&metadata)?;
         debug!("culture = {:?}", culture);
-        let linker_args = self.linker_args(&manifest);
+        let linker_args = self.linker_args(&metadata);
         debug!("linker_args = {:?}", linker_args);
-        let locale = self.locale(&manifest)?;
+        let locale = self.locale(&metadata)?;
         debug!("locale = {:?}", locale);
         let platform = self.platform();
         debug!("platform = {:?}", platform);
-        let debug_build = self.debug_build(&manifest);
+        let debug_build = self.debug_build(&metadata);
         debug!("debug_build = {:?}", debug_build);
-        let debug_name = self.debug_name(&manifest);
+        let debug_name = self.debug_name(&metadata);
         debug!("debug_name = {:?}", debug_name);
-        let wxs_sources = self.wxs_sources(&manifest)?;
+        let wxs_sources = self.wxs_sources(&package)?;
         debug!("wxs_sources = {:?}", wxs_sources);
         let wixobj_destination = self.wixobj_destination()?;
         debug!("wixobj_destination = {:?}", wixobj_destination);
-        let no_build = self.no_build(&manifest);
+        let no_build = self.no_build(&metadata);
         debug!("no_build = {:?}", no_build);
         if no_build {
             warn!("Skipped building the release binary");
@@ -475,7 +489,8 @@ impl Execution {
             platform,
             debug_name,
             &installer_kind,
-            &manifest,
+            &package,
+            &manifest.target_directory,
         )?;
         debug!("installer_destination = {:?}", installer_destination);
         // Link the installer
@@ -594,16 +609,12 @@ impl Execution {
         }
     }
 
-    fn debug_build(&self, manifest: &Value) -> bool {
+    fn debug_build(&self, metadata: &Value) -> bool {
         if self.debug_build {
             true
-        } else if let Some(pkg_meta_wix_debug_build) = manifest
-            .get("package")
-            .and_then(|p| p.as_table())
-            .and_then(|t| t.get("metadata"))
-            .and_then(|m| m.as_table())
-            .and_then(|t| t.get("wix"))
-            .and_then(|w| w.as_table())
+        } else if let Some(pkg_meta_wix_debug_build) = metadata
+            .get("wix")
+            .and_then(|w| w.as_object())
             .and_then(|t| t.get("dbg-build"))
             .and_then(|c| c.as_bool())
         {
@@ -613,16 +624,12 @@ impl Execution {
         }
     }
 
-    fn debug_name(&self, manifest: &Value) -> bool {
+    fn debug_name(&self, metadata: &Value) -> bool {
         if self.debug_name {
             true
-        } else if let Some(pkg_meta_wix_debug_name) = manifest
-            .get("package")
-            .and_then(|p| p.as_table())
-            .and_then(|t| t.get("metadata"))
-            .and_then(|m| m.as_table())
-            .and_then(|t| t.get("wix"))
-            .and_then(|w| w.as_table())
+        } else if let Some(pkg_meta_wix_debug_name) = metadata
+            .get("wix")
+            .and_then(|w| w.as_object())
             .and_then(|t| t.get("dbg-name"))
             .and_then(|c| c.as_bool())
         {
@@ -632,16 +639,12 @@ impl Execution {
         }
     }
 
-    fn no_build(&self, manifest: &Value) -> bool {
+    fn no_build(&self, metadata: &Value) -> bool {
         if self.no_build {
             true
-        } else if let Some(pkg_meta_wix_no_build) = manifest
-            .get("package")
-            .and_then(|p| p.as_table())
-            .and_then(|t| t.get("metadata"))
-            .and_then(|m| m.as_table())
-            .and_then(|t| t.get("wix"))
-            .and_then(|w| w.as_table())
+        } else if let Some(pkg_meta_wix_no_build) = metadata
+            .get("wix")
+            .and_then(|w| w.as_object())
             .and_then(|t| t.get("no-build"))
             .and_then(|c| c.as_bool())
         {
@@ -651,14 +654,10 @@ impl Execution {
         }
     }
 
-    fn compiler_args(&self, manifest: &Value) -> Option<Vec<String>> {
-        manifest
-            .get("package")
-            .and_then(|p| p.as_table())
-            .and_then(|t| t.get("metadata"))
-            .and_then(|m| m.as_table())
-            .and_then(|t| t.get("wix"))
-            .and_then(|w| w.as_table())
+    fn compiler_args(&self, metadata: &Value) -> Option<Vec<String>> {
+        metadata
+            .get("wix")
+            .and_then(|w| w.as_object())
             .and_then(|t| t.get("compiler-args"))
             .and_then(|i| i.as_array())
             .map(|a| {
@@ -669,14 +668,10 @@ impl Execution {
             .or_else(|| self.compiler_args.to_owned())
     }
 
-    fn linker_args(&self, manifest: &Value) -> Option<Vec<String>> {
-        manifest
-            .get("package")
-            .and_then(|p| p.as_table())
-            .and_then(|t| t.get("metadata"))
-            .and_then(|m| m.as_table())
-            .and_then(|t| t.get("wix"))
-            .and_then(|w| w.as_table())
+    fn linker_args(&self, metadata: &Value) -> Option<Vec<String>> {
+        metadata
+            .get("wix")
+            .and_then(|w| w.as_object())
             .and_then(|t| t.get("linker-args"))
             .and_then(|i| i.as_array())
             .map(|a| {
@@ -687,16 +682,12 @@ impl Execution {
             .or_else(|| self.linker_args.to_owned())
     }
 
-    fn culture(&self, manifest: &Value) -> Result<Cultures> {
+    fn culture(&self, metadata: &Value) -> Result<Cultures> {
         if let Some(culture) = &self.culture {
             Cultures::from_str(culture)
-        } else if let Some(pkg_meta_wix_culture) = manifest
-            .get("package")
-            .and_then(|p| p.as_table())
-            .and_then(|t| t.get("metadata"))
-            .and_then(|m| m.as_table())
-            .and_then(|t| t.get("wix"))
-            .and_then(|w| w.as_table())
+        } else if let Some(pkg_meta_wix_culture) = metadata
+            .get("wix")
+            .and_then(|w| w.as_object())
             .and_then(|t| t.get("culture"))
             .and_then(|c| c.as_str())
         {
@@ -706,7 +697,7 @@ impl Execution {
         }
     }
 
-    fn locale(&self, manifest: &Value) -> Result<Option<PathBuf>> {
+    fn locale(&self, metadata: &Value) -> Result<Option<PathBuf>> {
         if let Some(locale) = self.locale.as_ref().map(PathBuf::from) {
             if locale.exists() {
                 Ok(Some(locale))
@@ -717,13 +708,9 @@ impl Execution {
                     locale.display()
                 )))
             }
-        } else if let Some(pkg_meta_wix_locale) = manifest
-            .get("package")
-            .and_then(|p| p.as_table())
-            .and_then(|t| t.get("metadata"))
-            .and_then(|m| m.as_table())
-            .and_then(|t| t.get("wix"))
-            .and_then(|w| w.as_table())
+        } else if let Some(pkg_meta_wix_locale) = metadata
+            .get("wix")
+            .and_then(|w| w.as_object())
             .and_then(|t| t.get("locale"))
             .and_then(|l| l.as_str())
             .map(PathBuf::from)
@@ -796,29 +783,20 @@ impl Execution {
         }
     }
 
-    fn name(&self, manifest: &Value) -> Result<String> {
+    fn name(&self, package: &Package) -> Result<String> {
         if let Some(ref p) = self.name {
             Ok(p.to_owned())
-        } else if let Some(pkg_meta_wix_name) = manifest
-            .get("package")
-            .and_then(|p| p.as_table())
-            .and_then(|t| t.get("metadata"))
-            .and_then(|m| m.as_table())
-            .and_then(|t| t.get("wix"))
-            .and_then(|w| w.as_table())
+        } else if let Some(pkg_meta_wix_name) = package
+            .metadata
+            .get("wix")
+            .and_then(|w| w.as_object())
             .and_then(|t| t.get("name"))
             .and_then(|n| n.as_str())
             .map(String::from)
         {
             Ok(pkg_meta_wix_name)
         } else {
-            manifest
-                .get("package")
-                .and_then(|p| p.as_table())
-                .and_then(|t| t.get("name"))
-                .and_then(|n| n.as_str())
-                .map(String::from)
-                .ok_or(Error::Manifest("name"))
+            Ok(package.name.clone())
         }
     }
 
@@ -829,7 +807,8 @@ impl Execution {
         platform: Platform,
         debug_name: bool,
         installer_kind: &InstallerKind,
-        manifest: &Value,
+        package: &Package,
+        target_directory: &Path,
     ) -> Result<PathBuf> {
         let filename = if debug_name {
             format!(
@@ -856,13 +835,10 @@ impl Execution {
             } else {
                 Ok(path.to_owned())
             }
-        } else if let Some(pkg_meta_wix_output) = manifest
-            .get("package")
-            .and_then(|p| p.as_table())
-            .and_then(|t| t.get("metadata"))
-            .and_then(|m| m.as_table())
-            .and_then(|t| t.get("wix"))
-            .and_then(|w| w.as_table())
+        } else if let Some(pkg_meta_wix_output) = package
+            .metadata
+            .get("wix")
+            .and_then(|w| w.as_object())
             .and_then(|t| t.get("output"))
             .and_then(|o| o.as_str())
         {
@@ -876,26 +852,9 @@ impl Execution {
             } else {
                 Ok(path.to_owned())
             }
-        } else if let Some(manifest_path) = &self.input {
-            trace!("Using the package's manifest (Cargo.toml) file path to specify the MSI destination");
-            // Remove the `Cargo.toml` file from the path
-            manifest_path
-                .parent()
-                .ok_or_else(|| {
-                    Error::Generic(format!(
-                        "The '{}' path for the package's manifest file is invalid",
-                        manifest_path.display()
-                    ))
-                })
-                .map(|d| {
-                    PathBuf::from(d)
-                        .join(TARGET_FOLDER_NAME)
-                        .join(WIX)
-                        .join(filename)
-                })
         } else {
             trace!("Using the current working directory (CWD) to build the WiX object files destination");
-            Ok(PathBuf::from(TARGET_FOLDER_NAME).join(WIX).join(filename))
+            Ok(target_directory.to_owned())
         }
     }
 
@@ -946,7 +905,7 @@ impl Execution {
         }
     }
 
-    fn wxs_sources(&self, manifest: &Value) -> Result<Vec<PathBuf>> {
+    fn wxs_sources(&self, package: &Package) -> Result<Vec<PathBuf>> {
         let project_wix_dir = if let Some(manifest_path) = &self.input {
             trace!("Using the package's manifest (Cargo.toml) file path to obtain all WXS files");
             manifest_path
@@ -996,13 +955,10 @@ impl Execution {
                 }
             }
             wix_sources.extend(paths.clone());
-        } else if let Some(pkg_meta_wix_sources) = manifest
-            .get("package")
-            .and_then(|p| p.as_table())
-            .and_then(|t| t.get("metadata"))
-            .and_then(|m| m.as_table())
-            .and_then(|t| t.get("wix"))
-            .and_then(|w| w.as_table())
+        } else if let Some(pkg_meta_wix_sources) = package
+            .metadata
+            .get("wix")
+            .and_then(|w| w.as_object())
             .and_then(|t| t.get("include"))
             .and_then(|i| i.as_array())
             .map(|a| {
@@ -1048,28 +1004,19 @@ impl Execution {
         }
     }
 
-    fn version(&self, manifest: &Value) -> Result<Version> {
+    fn version(&self, package: &Package) -> Result<Version> {
         if let Some(ref v) = self.version {
             Version::parse(v).map_err(Error::from)
-        } else if let Some(pkg_meta_wix_version) = manifest
-            .get("package")
-            .and_then(|p| p.as_table())
-            .and_then(|t| t.get("metadata"))
-            .and_then(|m| m.as_table())
-            .and_then(|t| t.get("wix"))
-            .and_then(|w| w.as_table())
+        } else if let Some(pkg_meta_wix_version) = package
+            .metadata
+            .get("wix")
+            .and_then(|w| w.as_object())
             .and_then(|t| t.get("version"))
             .and_then(|v| v.as_str())
         {
             Version::parse(pkg_meta_wix_version).map_err(Error::from)
         } else {
-            manifest
-                .get("package")
-                .and_then(|p| p.as_table())
-                .and_then(|t| t.get("version"))
-                .and_then(|v| v.as_str())
-                .ok_or(Error::Manifest("version"))
-                .and_then(|s| Version::parse(s).map_err(Error::from))
+            Ok(package.version.clone())
         }
     }
 }
@@ -1514,10 +1461,11 @@ mod tests {
 
         #[test]
         fn debug_build_metadata_works() {
-            const PKG_META_WIX: &str = r#"
-                [package.metadata.wix]
-                dbg-build = true
-            "#;
+            const PKG_META_WIX: &str = r#"{
+                "wix": {
+                    "dbg-build": true
+                }
+            }"#;
             let execution = Execution::default();
             let debug_build = execution.debug_build(&PKG_META_WIX.parse::<Value>().unwrap());
             assert!(debug_build);
@@ -1525,10 +1473,11 @@ mod tests {
 
         #[test]
         fn debug_name_metadata_works() {
-            const PKG_META_WIX: &str = r#"
-                [package.metadata.wix]
-                dbg-name = true
-            "#;
+            const PKG_META_WIX: &str = r#"{
+                "wix": {
+                    "dbg-name": true
+                }
+            }"#;
             let execution = Execution::default();
             let debug_name = execution.debug_name(&PKG_META_WIX.parse::<Value>().unwrap());
             assert!(debug_name);
@@ -1537,41 +1486,62 @@ mod tests {
         #[test]
         fn version_metadata_works() {
             const PKG_META_WIX: &str = r#"
-                [package]
-                version = "0.1.0"
+            {
+                "name": "Example",
+                "version": "0.1.0",
+                "authors": ["First Last <first.last@example.com>"],
+                "license": "Apache-2.0",
 
-                [package.metadata.wix]
-                version = "2.1.0"
-            "#;
+                "id": "",
+                "dependencies": [],
+                "targets": [],
+                "features": {},
+                "manifest_path": "",
+
+                "metadata": {
+                    "wix": {
+                        "version": "2.1.0"
+                    }
+                }
+            }"#;
             let execution = Execution::default();
             let version = execution
-                .version(&PKG_META_WIX.parse::<Value>().unwrap())
+                .version(&serde_json::from_str(PKG_META_WIX).unwrap())
                 .unwrap();
             assert_eq!(version, Version::parse("2.1.0").unwrap());
         }
 
         #[test]
         fn name_metadata_works() {
-            const PKG_META_WIX: &str = r#"
-                [package]
-                name = "example"
+            const PKG_META_WIX: &str = r#"{
+                "name": "Example",
+                "version": "0.1.0",
+                "metadata": {
+                    "wix": {
+                        "name": "Metadata"
+                    }
+                },
 
-                [package.metadata.wix]
-                name = "Metadata"
-            "#;
+                "id": "",
+                "dependencies": [],
+                "targets": [],
+                "features": {},
+                "manifest_path": ""
+            }"#;
             let execution = Execution::default();
             let name = execution
-                .name(&PKG_META_WIX.parse::<Value>().unwrap())
+                .name(&serde_json::from_str(PKG_META_WIX).unwrap())
                 .unwrap();
             assert_eq!(name, "Metadata".to_owned());
         }
 
         #[test]
         fn no_build_metadata_works() {
-            const PKG_META_WIX: &str = r#"
-                [package.metadata.wix]
-                no-build = true
-            "#;
+            const PKG_META_WIX: &str = r#"{
+                "wix": {
+                    "no-build": true
+                }
+            }"#;
             let execution = Execution::default();
             let no_build = execution.no_build(&PKG_META_WIX.parse::<Value>().unwrap());
             assert!(no_build);
@@ -1579,10 +1549,11 @@ mod tests {
 
         #[test]
         fn culture_metadata_works() {
-            const PKG_META_WIX: &str = r#"
-                [package.metadata.wix]
-                culture = "Fr-Fr"
-            "#;
+            const PKG_META_WIX: &str = r#"{
+                "wix": {
+                    "culture": "Fr-Fr"
+                }
+            }"#;
             let execution = Execution::default();
             let culture = execution
                 .culture(&PKG_META_WIX.parse::<Value>().unwrap())
@@ -1592,10 +1563,11 @@ mod tests {
 
         #[test]
         fn locale_metadata_works() {
-            const PKG_META_WIX: &str = r#"
-                [package.metadata.wix]
-                locale = "wix/French.wxl"
-            "#;
+            const PKG_META_WIX: &str = r#"{
+                "wix": {
+                    "locale": "wix/French.wxl"
+                }
+            }"#;
             let execution = Execution::default();
             let locale = execution
                 .locale(&PKG_META_WIX.parse::<Value>().unwrap())
@@ -1605,10 +1577,23 @@ mod tests {
 
         #[test]
         fn output_metadata_works() {
-            const PKG_META_WIX: &str = r#"
-                [package.metadata.wix]
-                output = "target/wix/test.msi"
-            "#;
+            const PKG_META_WIX: &str = r#"{
+                "name": "Example",
+                "version": "0.1.0",
+                "authors": ["First Last <first.last@example.com>"],
+                "license": "XYZ",
+
+                "id": "",
+                "dependencies": [],
+                "targets": [],
+                "features": {},
+                "manifest_path": "",
+                "metadata": {
+                    "wix": {
+                        "output": "target/wix/test.msi"
+                    }
+                }
+            }"#;
             let execution = Execution::default();
             let output = execution
                 .installer_destination(
@@ -1617,7 +1602,8 @@ mod tests {
                     Platform::X64,
                     false,
                     &InstallerKind::default(),
-                    &PKG_META_WIX.parse::<Value>().unwrap(),
+                    &serde_json::from_str(PKG_META_WIX).unwrap(),
+                    Path::new("target/")
                 )
                 .unwrap();
             assert_eq!(output, PathBuf::from("target/wix/test.msi"));
@@ -1625,23 +1611,37 @@ mod tests {
 
         #[test]
         fn include_metadata_works() {
-            const PKG_META_WIX: &str = r#"
-                [package.metadata.wix]
-                include = ["Cargo.toml"]
-            "#;
+            const PKG_META_WIX: &str = r#"{
+                "name": "Example",
+                "version": "0.1.0",
+                "authors": ["First Last <first.last@example.com>"],
+                "license": "XYZ",
+
+                "id": "",
+                "dependencies": [],
+                "targets": [],
+                "features": {},
+                "manifest_path": "",
+                "metadata": {
+                    "wix": {
+                        "include": ["Cargo.toml"]
+                    }
+                }
+            }"#;
             let execution = Execution::default();
             let sources = execution
-                .wxs_sources(&PKG_META_WIX.parse::<Value>().unwrap())
+                .wxs_sources(&serde_json::from_str(PKG_META_WIX).unwrap())
                 .unwrap();
             assert_eq!(sources, vec![PathBuf::from("Cargo.toml")]);
         }
 
         #[test]
         fn compiler_args_metadata_works() {
-            const PKG_META_WIX: &str = r#"
-                [package.metadata.wix]
-                compiler-args = ["-nologo", "-ws"]
-            "#;
+            const PKG_META_WIX: &str = r#"{
+                "wix": {
+                    "compiler-args": ["-nologo", "-ws"]
+                }
+            }"#;
             let execution = Execution::default();
             let args = execution.compiler_args(&PKG_META_WIX.parse::<Value>().unwrap());
             assert_eq!(
@@ -1652,10 +1652,11 @@ mod tests {
 
         #[test]
         fn linker_args_metadata_works() {
-            const PKG_META_WIX: &str = r#"
-                [package.metadata.wix]
-                linker-args = ["-nologo", "-ws"]
-            "#;
+            const PKG_META_WIX: &str = r#"{
+                "wix": {
+                    "linker-args": ["-nologo", "-ws"]
+                }
+            }"#;
             let execution = Execution::default();
             let args = execution.linker_args(&PKG_META_WIX.parse::<Value>().unwrap());
             assert_eq!(
@@ -1664,7 +1665,7 @@ mod tests {
             );
         }
 
-        const EMPTY_PKG_META_WIX: &str = r#"[package.metadata.wix]"#;
+        const EMPTY_PKG_META_WIX: &str = r#"{"wix": {}}"#;
 
         #[test]
         fn culture_works() {
@@ -1714,7 +1715,7 @@ mod tests {
             let execution = Execution::default();
             assert_eq!(
                 execution.wixobj_destination().unwrap(),
-                PathBuf::from("target\\wix\\")
+                PathBuf::from("target").join("wix")
             )
         }
     }

--- a/src/create.rs
+++ b/src/create.rs
@@ -46,6 +46,7 @@ use std::io::{ErrorKind, Read};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::str::FromStr;
+use std::ffi::OsString;
 
 use cargo_metadata::{Metadata, Package, MetadataCommand};
 use serde_json::Value;
@@ -442,6 +443,11 @@ impl Execution {
         compiler
             .arg(format!("-dVersion={}", version))
             .arg(format!("-dPlatform={}", platform))
+            .arg({
+                let mut s = OsString::from("-dCargoTargetDir=");
+                s.push(&manifest.target_directory);
+                s
+            })
             .arg("-ext")
             .arg("WixUtilExtension")
             .arg("-o")

--- a/src/create.rs
+++ b/src/create.rs
@@ -894,21 +894,17 @@ impl Execution {
     }
 
     fn wxs_sources(&self, package: &Package) -> Result<Vec<PathBuf>> {
-        let project_wix_dir = if let Some(manifest_path) = &self.input {
-            trace!("Using the package's manifest (Cargo.toml) file path to obtain all WXS files");
-            manifest_path
-                .parent()
-                .ok_or_else(|| {
-                    Error::Generic(format!(
-                        "The '{}' path for the package's manifest file is invalid",
-                        manifest_path.display()
-                    ))
-                })
-                .map(|d| PathBuf::from(d).join(WIX))
-        } else {
-            trace!("Using the current working directory (CWD) to obtain all WXS files");
-            Ok(PathBuf::from(WIX))
-        }?;
+        trace!("Using the package's manifest (Cargo.toml) file path to obtain all WXS files");
+        let project_wix_dir = package
+            .manifest_path
+            .parent()
+            .ok_or_else(|| {
+                Error::Generic(format!(
+                    "The '{}' path for the package's manifest file is invalid",
+                    package.manifest_path.display()
+                ))
+            })
+            .map(|d| PathBuf::from(d).join(WIX))?;
         let mut wix_sources = {
             if project_wix_dir.exists() {
                 std::fs::read_dir(project_wix_dir)?
@@ -1609,7 +1605,7 @@ mod tests {
                 "dependencies": [],
                 "targets": [],
                 "features": {},
-                "manifest_path": "",
+                "manifest_path": "C:\\Cargo.toml",
                 "metadata": {
                     "wix": {
                         "include": ["Cargo.toml"]

--- a/src/initialize.rs
+++ b/src/initialize.rs
@@ -455,6 +455,7 @@ impl Execution {
             wxs_printer.license(license_wxs_path.as_deref().and_then(Path::to_str));
             wxs_printer.manufacturer(self.manufacturer.as_ref().map(String::as_ref));
             wxs_printer.output(destination.as_path().to_str());
+            wxs_printer.package(self.package.as_deref());
             wxs_printer.product_icon(self.product_icon.as_deref().and_then(Path::to_str));
             wxs_printer.product_name(self.product_name.as_ref().map(String::as_ref));
             wxs_printer.build().run()?;

--- a/src/initialize.rs
+++ b/src/initialize.rs
@@ -387,13 +387,14 @@ impl Execution {
         debug!("product_icon = {:?}", self.product_icon);
         debug!("product_name = {:?}", self.product_name);
         let manifest = super::manifest(self.input.as_ref())?;
+        let package = super::package(&manifest, None)?;
         let mut destination = self.destination()?;
         debug!("destination = {:?}", destination);
         if !destination.exists() {
             info!("Creating the '{}' directory", destination.display());
             fs::create_dir(&destination)?;
         }
-        let (eula_wxs_path, license_wxs_path) = match Eula::new(self.eula.as_ref(), &manifest)? {
+        let (eula_wxs_path, license_wxs_path) = match Eula::new(self.eula.as_ref(), &package)? {
             Eula::CommandLine(path) => (Some(path), self.license),
             Eula::Manifest(path) => (Some(path), self.license),
             Eula::Generate(template) => {

--- a/src/initialize.rs
+++ b/src/initialize.rs
@@ -471,9 +471,9 @@ impl Execution {
                     Ok(input
                         .parent()
                         .map(|p| p.to_path_buf())
-                        .and_then(|mut p| {
+                        .map(|mut p| {
                             p.push(WIX);
-                            Some(p)
+                            p
                         })
                         .unwrap())
                 } else {
@@ -494,9 +494,9 @@ impl Execution {
                     Ok(cwd
                         .parent()
                         .map(|p| p.to_path_buf())
-                        .and_then(|mut p| {
+                        .map(|mut p| {
                             p.push(WIX);
-                            Some(p)
+                            p
                         })
                         .unwrap())
                 } else {

--- a/src/initialize.rs
+++ b/src/initialize.rs
@@ -54,6 +54,7 @@ pub struct Builder<'a> {
     license: Option<&'a str>,
     manufacturer: Option<&'a str>,
     output: Option<&'a str>,
+    package: Option<&'a str>,
     product_icon: Option<&'a str>,
     product_name: Option<&'a str>,
 }
@@ -75,9 +76,16 @@ impl<'a> Builder<'a> {
             license: None,
             manufacturer: None,
             output: None,
+            package: None,
             product_icon: None,
             product_name: None,
         }
+    }
+
+    /// Sets the package on which to operate during this build
+    pub fn package(&mut self, p: Option<&'a str>) -> &mut Self {
+        self.package = p;
+        self
     }
 
     /// Sets the path to a bitmap (BMP) file to be used as a banner image across
@@ -335,6 +343,7 @@ impl<'a> Builder<'a> {
             license: self.license.map(PathBuf::from),
             manufacturer: self.manufacturer.map(String::from),
             output: self.output.map(PathBuf::from),
+            package: self.package.map(String::from),
             product_icon: self.product_icon.map(PathBuf::from),
             product_name: self.product_name.map(String::from),
         }
@@ -363,6 +372,7 @@ pub struct Execution {
     license: Option<PathBuf>,
     manufacturer: Option<String>,
     output: Option<PathBuf>,
+    package: Option<String>,
     product_icon: Option<PathBuf>,
     product_name: Option<String>,
 }
@@ -384,10 +394,11 @@ impl Execution {
         debug!("license = {:?}", self.license);
         debug!("manufacturer = {:?}", self.manufacturer);
         debug!("output = {:?}", self.output);
+        debug!("package = {:?}", self.package);
         debug!("product_icon = {:?}", self.product_icon);
         debug!("product_name = {:?}", self.product_name);
         let manifest = super::manifest(self.input.as_ref())?;
-        let package = super::package(&manifest, None)?;
+        let package = super::package(&manifest, self.package.as_deref())?;
         let mut destination = self.destination()?;
         debug!("destination = {:?}", destination);
         if !destination.exists() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,7 +197,12 @@ fn package(manifest: &Metadata, package: Option<&str>) -> Result<Package> {
             .workspace_members
             .iter()
             .find(|u| manifest[u].name == v)
-            .unwrap()
+            .ok_or_else(|| {
+                Error::Generic(format!(
+                    "package ID specification `{}` matched no packages",
+                    v
+                ))
+            })?
     } else if manifest.workspace_members.len() == 1 {
         &manifest.workspace_members[0]
     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,7 +186,7 @@ fn package_root(input: Option<&PathBuf>) -> Result<PathBuf> {
 fn manifest(input: Option<&PathBuf>) -> Result<Metadata> {
     let cargo_file_path = cargo_toml_file(input)?;
     debug!("cargo_file_path = {:?}", cargo_file_path);
-    Ok(MetadataCommand::new().exec().unwrap())
+    Ok(MetadataCommand::new().manifest_path(cargo_file_path).exec().unwrap())
 }
 
 fn package(manifest: &Metadata, package: Option<&str>) -> Result<Package> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,8 +91,7 @@ use std::env;
 use std::error::Error as StdError;
 use std::ffi::OsStr;
 use std::fmt;
-use std::fs::File;
-use std::io::{self, ErrorKind, Read};
+use std::io::{self, ErrorKind};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,10 +126,6 @@ pub const SIGNTOOL: &str = "signtool";
 /// application.
 pub const SIGNTOOL_PATH_KEY: &str = "SIGNTOOL_PATH";
 
-/// The name of the folder where output from the builder, compiler, linker, and
-/// signer.
-pub const TARGET_FOLDER_NAME: &str = "target";
-
 /// The default name of the folder for output from this subcommand.
 pub const WIX: &str = "wix";
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@ use std::io::{self, ErrorKind, Read};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
-use toml::Value;
+use cargo_metadata::{MetadataCommand, Metadata, Package};
 
 /// The name of the folder where binaries are typically stored.
 pub const BINARY_FOLDER_NAME: &str = "bin";
@@ -180,45 +180,43 @@ fn cargo_toml_file(input: Option<&PathBuf>) -> Result<PathBuf> {
 }
 
 fn package_root(input: Option<&PathBuf>) -> Result<PathBuf> {
-    cargo_toml_file(input).and_then(|p| {
-        Ok(p.parent()
+    cargo_toml_file(input).map(|p| {
+        p.parent()
             .map(PathBuf::from)
-            .expect("The Cargo.toml file to NOT be root."))
+            .expect("The Cargo.toml file to NOT be root.")
     })
 }
 
-fn manifest(input: Option<&PathBuf>) -> Result<Value> {
+fn manifest(input: Option<&PathBuf>) -> Result<Metadata> {
     let cargo_file_path = cargo_toml_file(input)?;
     debug!("cargo_file_path = {:?}", cargo_file_path);
-    let mut cargo_file = File::open(cargo_file_path)?;
-    let mut cargo_file_content = String::new();
-    cargo_file.read_to_string(&mut cargo_file_content)?;
-    let manifest = cargo_file_content.parse::<Value>()?;
-    Ok(manifest)
+    Ok(MetadataCommand::new().exec().unwrap())
 }
 
-fn description(description: Option<String>, manifest: &Value) -> Option<String> {
+fn package(manifest: &Metadata, package: Option<&str>) -> Result<Package> {
+    let package_id = if let Some(v) = package {
+        manifest.workspace_members.iter().find(|u| {
+            manifest[u].name == v
+        }).unwrap()
+    } else if manifest.workspace_members.len() == 1 {
+        &manifest.workspace_members[0]
+    } else {
+        return Err(Error::Generic(String::from("Workspace detected. Please pass a package name.")))
+    };
+    Ok(manifest[package_id].clone())
+}
+
+fn description(description: Option<String>, manifest: &Package) -> Option<String> {
     description.or_else(|| {
-        manifest
-            .get("package")
-            .and_then(|p| p.as_table())
-            .and_then(|t| t.get("description"))
-            .and_then(|d| d.as_str())
-            .map(String::from)
+        manifest.description.clone()
     })
 }
 
-fn product_name(product_name: Option<&String>, manifest: &Value) -> Result<String> {
+fn product_name(product_name: Option<&String>, manifest: &Package) -> Result<String> {
     if let Some(p) = product_name {
         Ok(p.to_owned())
     } else {
-        manifest
-            .get("package")
-            .and_then(|p| p.as_table())
-            .and_then(|t| t.get("name"))
-            .and_then(|n| n.as_str())
-            .map(String::from)
-            .ok_or(Error::Manifest("name"))
+        Ok(manifest.name.clone())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ use std::io::{self, ErrorKind};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
-use cargo_metadata::{MetadataCommand, Metadata, Package};
+use cargo_metadata::{Metadata, MetadataCommand, Package};
 
 /// The name of the folder where binaries are typically stored.
 pub const BINARY_FOLDER_NAME: &str = "bin";
@@ -185,26 +185,31 @@ fn package_root(input: Option<&PathBuf>) -> Result<PathBuf> {
 fn manifest(input: Option<&PathBuf>) -> Result<Metadata> {
     let cargo_file_path = cargo_toml_file(input)?;
     debug!("cargo_file_path = {:?}", cargo_file_path);
-    Ok(MetadataCommand::new().manifest_path(cargo_file_path).exec().unwrap())
+    Ok(MetadataCommand::new()
+        .manifest_path(cargo_file_path)
+        .exec()
+        .unwrap())
 }
 
 fn package(manifest: &Metadata, package: Option<&str>) -> Result<Package> {
     let package_id = if let Some(v) = package {
-        manifest.workspace_members.iter().find(|u| {
-            manifest[u].name == v
-        }).unwrap()
+        manifest
+            .workspace_members
+            .iter()
+            .find(|u| manifest[u].name == v)
+            .unwrap()
     } else if manifest.workspace_members.len() == 1 {
         &manifest.workspace_members[0]
     } else {
-        return Err(Error::Generic(String::from("Workspace detected. Please pass a package name.")))
+        return Err(Error::Generic(String::from(
+            "Workspace detected. Please pass a package name.",
+        )));
     };
     Ok(manifest[package_id].clone())
 }
 
 fn description(description: Option<String>, manifest: &Package) -> Option<String> {
-    description.or_else(|| {
-        manifest.description.clone()
-    })
+    description.or_else(|| manifest.description.clone())
 }
 
 fn product_name(product_name: Option<&String>, manifest: &Package) -> Result<String> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -956,6 +956,21 @@ impl Default for Cultures {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use assert_fs::TempDir;
+    use std::env;
+    use std::fs;
+
+    /// Create a simple project with the provided TOML.
+    pub fn setup_project(toml: &str) -> TempDir {
+        pub const PERSIST_VAR_NAME: &str = "CARGO_WIX_TEST_PERSIST";
+
+        let temp_dir = TempDir::new().unwrap();
+        fs::write(temp_dir.path().join("Cargo.toml"), toml).unwrap();
+        fs::create_dir(temp_dir.path().join("src")).unwrap();
+        fs::write(temp_dir.path().join("src").join("main.rs"), "fn main() {}").unwrap();
+
+        temp_dir.into_persistent_if(env::var(PERSIST_VAR_NAME).is_ok())
+    }
 
     mod culture {
         use super::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1630,6 +1630,7 @@ fn main() {
             init.license(m.value_of("license"));
             init.manufacturer(m.value_of("manufacturer"));
             init.output(m.value_of("output"));
+            init.package(m.value_of("package"));
             init.product_icon(m.value_of("product-icon"));
             init.product_name(m.value_of("product-name"));
             init.build().run()
@@ -1649,6 +1650,7 @@ fn main() {
                     print.license(m.value_of("license"));
                     print.manufacturer(m.value_of("manufacturer"));
                     print.output(m.value_of("output"));
+                    print.package(m.value_of("package"));
                     print.product_icon(m.value_of("product-icon"));
                     print.product_name(m.value_of("product-name"));
                     print.build().run()
@@ -1675,6 +1677,7 @@ fn main() {
             sign.description(m.value_of("description"));
             sign.homepage(m.value_of("homepage"));
             sign.input(m.value_of("INPUT"));
+            sign.package(m.value_of("package"));
             sign.product_name(m.value_of("product-name"));
             sign.timestamp(m.value_of("timestamp"));
             sign.build().run()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1058,6 +1058,9 @@ use wix::{Cultures, Template, BINARY_FOLDER_NAME, WIX_PATH_KEY};
 const SUBCOMMAND_NAME: &str = "wix";
 
 fn main() {
+    let package = Arg::with_name("package")
+        .help("The name of the package in the current workspace to operate on")
+        .takes_value(true);
     // The banner option for the `init` and `print` subcommands.
     let banner = Arg::with_name("banner")
         .help("A path to an image file (.bmp) for the installer's banner")
@@ -1547,6 +1550,7 @@ fn main() {
                         .takes_value(true))
                     .arg(verbose.clone()))
                 .arg(verbose)
+                .arg(package)
         ).get_matches();
     let matches = matches.subcommand_matches(SUBCOMMAND_NAME).unwrap();
     let verbosity = match matches.subcommand() {
@@ -1690,6 +1694,7 @@ fn main() {
             create.no_build(matches.is_present("no-build"));
             create.output(matches.value_of("output"));
             create.version(matches.value_of("install-version"));
+            create.package(matches.value_of("package"));
             create.build().run()
         }
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1060,6 +1060,7 @@ const SUBCOMMAND_NAME: &str = "wix";
 fn main() {
     let package = Arg::with_name("package")
         .help("The name of the package in the current workspace to operate on")
+        .long("package")
         .takes_value(true);
     // The banner option for the `init` and `print` subcommands.
     let banner = Arg::with_name("banner")

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -28,7 +28,7 @@ use std::fs::File;
 use std::io::{self, Write};
 use std::path::PathBuf;
 
-use toml::Value;
+use cargo_metadata::Package;
 
 fn destination(output: Option<&PathBuf>) -> Result<Box<dyn Write>> {
     if let Some(ref output) = output {
@@ -44,14 +44,8 @@ fn destination(output: Option<&PathBuf>) -> Result<Box<dyn Write>> {
     }
 }
 
-fn first_author(manifest: &Value) -> Result<String> {
-    manifest
-        .get("package")
-        .and_then(|p| p.as_table())
-        .and_then(|t| t.get("authors"))
-        .and_then(|a| a.as_array())
-        .and_then(|a| a.get(0))
-        .and_then(|f| f.as_str())
+fn first_author(package: &Package) -> Result<String> {
+    package.authors.first()
         .and_then(|s| {
             // Strip email if it exists.
             let re = Regex::new(r"<(.*?)>").unwrap();
@@ -65,22 +59,33 @@ fn first_author(manifest: &Value) -> Result<String> {
 mod tests {
     use super::*;
 
-    const SINGLE_AUTHOR_MANIFEST: &str = r#"[package]
-            name = "Example"
-            version = "0.1.0"
-            authors = ["First Last <first.last@example.com>"]
-        "#;
+    const SINGLE_AUTHOR_MANIFEST: &str = r#"{
+            "name": "Example",
+            "version": "0.1.0",
+            "authors": ["First Last <first.last@example.com>"],
 
-    const MULTIPLE_AUTHORS_MANIFEST: &str = r#"[package]
-            name = "Example"
-            version = "0.1.0"
-            authors = ["1 Author <first.last@example.com>", "2 Author <2.author@example.com>", "3 author <3.author@example.com>"]
-        "#;
+            "id": "",
+            "dependencies": [],
+            "targets": [],
+            "features": {},
+            "manifest_path": ""
+        }"#;
+
+    const MULTIPLE_AUTHORS_MANIFEST: &str = r#"{
+            "name": "Example",
+            "version": "0.1.0",
+            "authors": ["1 Author <first.last@example.com>", "2 Author <2.author@example.com>", "3 author <3.author@example.com>"],
+
+            "id": "",
+            "dependencies": [],
+            "targets": [],
+            "features": {},
+            "manifest_path": ""
+        }"#;
 
     #[test]
     fn first_author_with_single_author_works() {
-        let manifest = SINGLE_AUTHOR_MANIFEST
-            .parse::<Value>()
+        let manifest = serde_json::from_str(SINGLE_AUTHOR_MANIFEST)
             .expect("Parsing TOML");
         let actual = first_author(&manifest).unwrap();
         assert_eq!(actual, String::from("First Last"));
@@ -88,8 +93,7 @@ mod tests {
 
     #[test]
     fn first_author_with_multiple_authors_works() {
-        let manifest = MULTIPLE_AUTHORS_MANIFEST
-            .parse::<Value>()
+        let manifest = serde_json::from_str(MULTIPLE_AUTHORS_MANIFEST)
             .expect("Parsing TOML");
         let actual = first_author(&manifest).unwrap();
         assert_eq!(actual, String::from("1 Author"));

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -46,10 +46,10 @@ fn destination(output: Option<&PathBuf>) -> Result<Box<dyn Write>> {
 
 fn first_author(package: &Package) -> Result<String> {
     package.authors.first()
-        .and_then(|s| {
+        .map(|s| {
             // Strip email if it exists.
             let re = Regex::new(r"<(.*?)>").unwrap();
-            Some(re.replace_all(s, ""))
+            re.replace_all(s, "")
         })
         .map(|s| String::from(s.trim()))
         .ok_or(Error::Manifest("authors"))

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -45,7 +45,9 @@ fn destination(output: Option<&PathBuf>) -> Result<Box<dyn Write>> {
 }
 
 fn first_author(package: &Package) -> Result<String> {
-    package.authors.first()
+    package
+        .authors
+        .first()
         .map(|s| {
             // Strip email if it exists.
             let re = Regex::new(r"<(.*?)>").unwrap();
@@ -85,16 +87,14 @@ mod tests {
 
     #[test]
     fn first_author_with_single_author_works() {
-        let manifest = serde_json::from_str(SINGLE_AUTHOR_MANIFEST)
-            .expect("Parsing TOML");
+        let manifest = serde_json::from_str(SINGLE_AUTHOR_MANIFEST).expect("Parsing TOML");
         let actual = first_author(&manifest).unwrap();
         assert_eq!(actual, String::from("First Last"));
     }
 
     #[test]
     fn first_author_with_multiple_authors_works() {
-        let manifest = serde_json::from_str(MULTIPLE_AUTHORS_MANIFEST)
-            .expect("Parsing TOML");
+        let manifest = serde_json::from_str(MULTIPLE_AUTHORS_MANIFEST).expect("Parsing TOML");
         let actual = first_author(&manifest).unwrap();
         assert_eq!(actual, String::from("1 Author"));
     }

--- a/src/print/wxs.rs
+++ b/src/print/wxs.rs
@@ -871,7 +871,7 @@ mod tests {
                 vec![hashmap! {
                     "binary-index" => 0.to_string(),
                     "binary-name" => String::from("Different"),
-                    "binary-source" => String::from("target\\$(var.Profile)\\Different.exe")
+                    "binary-source" => String::from("$(var.CargoTargetDir)\\$(var.Profile)\\Different.exe")
                 }]
             )
         }

--- a/src/print/wxs.rs
+++ b/src/print/wxs.rs
@@ -48,6 +48,7 @@ pub struct Builder<'a> {
     license: Option<&'a str>,
     manufacturer: Option<&'a str>,
     output: Option<&'a str>,
+    package: Option<&'a str>,
     product_icon: Option<&'a str>,
     product_name: Option<&'a str>,
 }
@@ -66,9 +67,16 @@ impl<'a> Builder<'a> {
             license: None,
             manufacturer: None,
             output: None,
+            package: None,
             product_icon: None,
             product_name: None,
         }
+    }
+
+    /// Sets the package on which to operate during this build
+    pub fn package(&mut self, p: Option<&'a str>) -> &mut Self {
+        self.package = p;
+        self
     }
 
     /// Sets the path to a bitmap (BMP) file to be used as a banner image across
@@ -248,6 +256,7 @@ impl<'a> Builder<'a> {
             license: self.license.map(PathBuf::from),
             manufacturer: self.manufacturer.map(String::from),
             output: self.output.map(PathBuf::from),
+            package: self.package.map(String::from),
             product_icon: self.product_icon.map(PathBuf::from),
             product_name: self.product_name.map(String::from),
         }
@@ -273,6 +282,7 @@ pub struct Execution {
     license: Option<PathBuf>,
     manufacturer: Option<String>,
     output: Option<PathBuf>,
+    package: Option<String>,
     product_icon: Option<PathBuf>,
     product_name: Option<String>,
 }
@@ -290,10 +300,11 @@ impl Execution {
         debug!("license = {:?}", self.license);
         debug!("manufacturer = {:?}", self.manufacturer);
         debug!("output = {:?}", self.output);
+        debug!("package = {:?}", self.package);
         debug!("product_icon = {:?}", self.product_icon);
         debug!("product_name = {:?}", self.product_name);
         let manifest = manifest(self.input.as_ref())?;
-        let package = package(&manifest, None)?;
+        let package = package(&manifest, self.package.as_deref())?;
         let mut destination = super::destination(self.output.as_ref())?;
         let template = mustache::compile_str(Template::Wxs.to_str())?;
         let binaries = self.binaries(&package)?;

--- a/src/print/wxs.rs
+++ b/src/print/wxs.rs
@@ -405,10 +405,10 @@ impl Execution {
             }
             binaries.push(map);
         } else {
-            let binaries_iter = package.targets
+            let binaries_iter = package
+                .targets
                 .iter()
-                .filter(|v|
-                    v.kind.iter().any(|v| v == "bin"));
+                .filter(|v| v.kind.iter().any(|v| v == "bin"));
             for (index, binary) in binaries_iter.enumerate() {
                 let mut map = HashMap::with_capacity(3);
                 map.insert("binary-index", index.to_string());
@@ -422,7 +422,9 @@ impl Execution {
 
     fn default_binary_path(name: &str) -> String {
         // TODO: Handle cross-compilation?
-        let mut path = Path::new("$(var.CargoTargetDir)").join("$(var.Profile)").join(name);
+        let mut path = Path::new("$(var.CargoTargetDir)")
+            .join("$(var.Profile)")
+            .join(name);
         path.set_extension(EXE_FILE_EXTENSION);
         path.to_str()
             .map(String::from)
@@ -431,11 +433,10 @@ impl Execution {
 
     fn help_url(manifest: &Package) -> Option<String> {
         // TODO: Get documentation || homepage || repository.
-        manifest.repository.as_ref()
-            .map(|s| {
-                trace!("Using '{}' for the help URL", s);
-                s.clone()
-            })
+        manifest.repository.as_ref().map(|s| {
+            trace!("Using '{}' for the help URL", s);
+            s.clone()
+        })
     }
 
     fn eula(&self, manifest: &Package) -> Result<Eula> {
@@ -457,21 +458,16 @@ impl Execution {
         if let Some(ref l) = self.license.clone().map(PathBuf::from) {
             l.file_name().and_then(|f| f.to_str()).map(String::from)
         } else {
-            manifest.license.as_ref()
-                .filter(|l| {
-                    Template::license_ids().contains(&l)
-                })
+            manifest
+                .license
+                .as_ref()
+                .filter(|l| Template::license_ids().contains(&l))
                 .map(|_| String::from(LICENSE_FILE_NAME))
                 .or_else(|| {
-                    manifest.license_file()
-                        .and_then(|l| {
-                            l
-                                .file_name()
-                                .and_then(|f| f.to_str())
-                                .map(String::from)
-                        })
+                    manifest
+                        .license_file()
+                        .and_then(|l| l.file_name().and_then(|f| f.to_str()).map(String::from))
                 })
-
         }
     }
 
@@ -479,24 +475,25 @@ impl Execution {
         if let Some(ref path) = self.license.clone().map(PathBuf::from) {
             Ok(path.to_str().map(String::from))
         } else {
-            Ok(manifest.license.as_ref()
-                .filter(|l| {
-                    Template::license_ids().contains(&l)
-                })
+            Ok(manifest
+                .license
+                .as_ref()
+                .filter(|l| Template::license_ids().contains(&l))
                 .map(|_| LICENSE_FILE_NAME.to_owned() + "." + RTF_FILE_EXTENSION)
                 .or_else(|| {
-                    manifest.license_file()
-                        .and_then(|s| {
-                            if s.exists() {
-                                trace!("The '{}' path from the 'license-file' field in the package's \
-                                    manifest (Cargo.toml) exists.", s.display());
-                                Some(s.into_os_string().into_string().unwrap())
-                            } else {
-                                None
-                            }
-                        })
-                })
-            )
+                    manifest.license_file().and_then(|s| {
+                        if s.exists() {
+                            trace!(
+                                "The '{}' path from the 'license-file' field in the package's \
+                                manifest (Cargo.toml) exists.",
+                                s.display()
+                            );
+                            Some(s.into_os_string().into_string().unwrap())
+                        } else {
+                            None
+                        }
+                    })
+                }))
         }
     }
 
@@ -878,9 +875,7 @@ mod tests {
 
         #[test]
         fn binaries_with_multiple_bin_sections_works() {
-            let manifest = serde_json::from_str(MULTIPLE_BIN_MANIFEST
-                )
-                .expect("Parsing TOML");
+            let manifest = serde_json::from_str(MULTIPLE_BIN_MANIFEST).expect("Parsing TOML");
             let actual = Execution::default().binaries(&manifest).unwrap();
             assert_eq!(
                 actual,
@@ -1011,7 +1006,8 @@ mod tests {
             let temp_dir = assert_fs::TempDir::new().unwrap();
             let license_file_path = temp_dir.path().join("Example.rtf");
             let _license_file_handle = File::create(&license_file_path).expect("Create file");
-            let manifest = serde_json::from_str(&format!(r#"{{
+            let manifest = serde_json::from_str(&format!(
+                r#"{{
                 "name": "Example",
                 "version": "0.1.0",
                 "authors": ["First Last <first.last@example.com>"],
@@ -1035,7 +1031,8 @@ mod tests {
             let temp_dir = assert_fs::TempDir::new().unwrap();
             let license_file_path = temp_dir.path().join("Example.txt");
             let _license_file_handle = File::create(&license_file_path).expect("Create file");
-            let manifest = serde_json::from_str(&format!(r#"{{
+            let manifest = serde_json::from_str(&format!(
+                r#"{{
                 "name": "Example",
                 "version": "0.1.0",
                 "authors": ["First Last <first.last@example.com>"],

--- a/src/print/wxs.rs
+++ b/src/print/wxs.rs
@@ -485,7 +485,7 @@ impl Execution {
                         if s.exists() {
                             trace!(
                                 "The '{}' path from the 'license-file' field in the package's \
-                                manifest (Cargo.toml) exists.",
+                                 manifest (Cargo.toml) exists.",
                                 s.display()
                             );
                             Some(s.into_os_string().into_string().unwrap())

--- a/src/print/wxs.rs
+++ b/src/print/wxs.rs
@@ -288,6 +288,7 @@ pub struct Execution {
 }
 
 impl Execution {
+    #[allow(clippy::cognitive_complexity)]
     /// Prints a WiX Source (wxs) file based on the built context.
     pub fn run(self) -> Result<()> {
         debug!("banner = {:?}", self.banner);

--- a/src/purge.rs
+++ b/src/purge.rs
@@ -103,9 +103,9 @@ impl Execution {
                     Ok(input
                         .parent()
                         .map(|p| p.to_path_buf())
-                        .and_then(|mut p| {
+                        .map(|mut p| {
                             p.push(WIX);
-                            Some(p)
+                            p
                         })
                         .unwrap())
                 } else {

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -33,7 +33,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::str::FromStr;
 
-use cargo_metadata::{Package};
+use cargo_metadata::Package;
 
 /// A builder for creating an execution context to sign an installer.
 #[derive(Debug, Clone)]
@@ -231,11 +231,11 @@ impl Execution {
             // TODO: Get cargo to return the homepage.
             None
             /*package.
-                .get("package")
-                .and_then(|p| p.as_table())
-                .and_then(|t| t.get("homepage"))
-                .and_then(|d| d.as_str())
-                .map(String::from)*/
+            .get("package")
+            .and_then(|p| p.as_table())
+            .and_then(|t| t.get("homepage"))
+            .and_then(|d| d.as_str())
+            .map(String::from)*/
         })
     }
 
@@ -451,8 +451,7 @@ mod tests {
 
         #[test]
         fn msi_with_nonexistent_installer_fails() {
-            let result = Execution::default()
-                .msi(Path::new("target"));
+            let result = Execution::default().msi(Path::new("target"));
             assert!(result.is_err());
         }
 

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -170,6 +170,7 @@ impl Execution {
         debug!("product_name = {:?}", self.product_name);
         debug!("timestamp = {:?}", self.timestamp);
         let manifest = super::manifest(self.input.as_ref())?;
+        debug!("target_directory = {:?}", manifest.target_directory);
         let package = super::package(&manifest, None)?;
         let product_name = super::product_name(self.product_name.as_ref(), &package)?;
         let description = if let Some(d) = super::description(self.description.clone(), &package) {

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -226,7 +226,7 @@ impl Execution {
         Ok(())
     }
 
-    fn homepage(&self, package: &Package) -> Option<String> {
+    fn homepage(&self, _package: &Package) -> Option<String> {
         self.homepage.clone().or_else(|| {
             // TODO: Get cargo to return the homepage.
             None

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -433,12 +433,12 @@ mod tests {
             assert!(actual.is_none());
         }
 
-        #[test]
-        fn homepage_with_homepage_field_works() {
-            let manifest = serde_json::from_str(HOMEPAGE_MANIFEST).expect("Parsing TOML");
-            let actual = Execution::default().homepage(&manifest);
-            assert_eq!(actual, Some(String::from("http://www.example.com")));
-        }
+        //#[test]
+        //fn homepage_with_homepage_field_works() {
+        //    let manifest = serde_json::from_str(HOMEPAGE_MANIFEST).expect("Parsing TOML");
+        //    let actual = Execution::default().homepage(&manifest);
+        //    assert_eq!(actual, Some(String::from("http://www.example.com")));
+        //}
 
         #[test]
         fn homepage_with_override_works() {

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -43,6 +43,7 @@ pub struct Builder<'a> {
     description: Option<&'a str>,
     homepage: Option<&'a str>,
     input: Option<&'a str>,
+    package: Option<&'a str>,
     product_name: Option<&'a str>,
     timestamp: Option<&'a str>,
 }
@@ -56,11 +57,17 @@ impl<'a> Builder<'a> {
             description: None,
             homepage: None,
             input: None,
+            package: None,
             product_name: None,
             timestamp: None,
         }
     }
 
+    /// Sets the package on which to operate during this build
+    pub fn package(&mut self, p: Option<&'a str>) -> &mut Self {
+        self.package = p;
+        self
+    }
     /// Sets the path to the folder containing the `signtool.exe` file.
     ///
     // Normally the `signtool.exe` is installed in the `bin` folder of the
@@ -134,6 +141,7 @@ impl<'a> Builder<'a> {
             description: self.description.map(String::from),
             homepage: self.homepage.map(String::from),
             input: self.input.map(PathBuf::from),
+            package: self.package.map(String::from),
             product_name: self.product_name.map(String::from),
             timestamp: self.timestamp.map(String::from),
         }
@@ -154,6 +162,7 @@ pub struct Execution {
     description: Option<String>,
     homepage: Option<String>,
     input: Option<PathBuf>,
+    package: Option<String>,
     product_name: Option<String>,
     timestamp: Option<String>,
 }
@@ -167,11 +176,12 @@ impl Execution {
         debug!("description = {:?}", self.description);
         debug!("homepage = {:?}", self.homepage);
         debug!("input = {:?}", self.input);
+        debug!("package = {:?}", self.package);
         debug!("product_name = {:?}", self.product_name);
         debug!("timestamp = {:?}", self.timestamp);
         let manifest = super::manifest(self.input.as_ref())?;
         debug!("target_directory = {:?}", manifest.target_directory);
-        let package = super::package(&manifest, None)?;
+        let package = super::package(&manifest, self.package.as_deref())?;
         let product_name = super::product_name(self.product_name.as_ref(), &package)?;
         let description = if let Some(d) = super::description(self.description.clone(), &package) {
             trace!("A description was provided either at the command line or in the package's manifest (Cargo.toml).");

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -37,6 +37,24 @@ pub const PERSIST_VAR_NAME: &str = "CARGO_WIX_TEST_PERSIST";
 
 pub const MISC_NAME: &str = "misc";
 
+pub const SUBPACKAGE1_NAME: &str = "subproject1";
+pub const SUBPACKAGE2_NAME: &str = "subproject2";
+
+fn create_test_package_at_path(path: &Path, package_name: &str) {
+    let cargo_init_status = Command::new("cargo")
+        .arg("init")
+        .arg("--bin")
+        .arg("--quiet")
+        .arg("--vcs")
+        .arg("none")
+        .arg("--name")
+        .arg(package_name)
+        .arg(path)
+        .status()
+        .expect("Creation of test Cargo package");
+    assert!(cargo_init_status.success());
+}
+
 /// Create a new cargo project/package for a binary project in a temporary
 /// directory.
 ///
@@ -60,18 +78,7 @@ pub const MISC_NAME: &str = "misc";
 /// fails to create the project/package.
 pub fn create_test_package() -> TempDir {
     let temp_dir = TempDir::new().unwrap();
-    let cargo_init_status = Command::new("cargo")
-        .arg("init")
-        .arg("--bin")
-        .arg("--quiet")
-        .arg("--vcs")
-        .arg("none")
-        .arg("--name")
-        .arg(PACKAGE_NAME)
-        .arg(temp_dir.path())
-        .status()
-        .expect("Creation of test Cargo package");
-    assert!(cargo_init_status.success());
+    create_test_package_at_path(temp_dir.path(), PACKAGE_NAME);
     temp_dir.into_persistent_if(env::var(PERSIST_VAR_NAME).is_ok())
 }
 
@@ -207,6 +214,20 @@ pub fn create_test_package_multiple_wxs_sources() -> TempDir {
     let mut three_wxs_handle = File::create(&misc_dir).unwrap();
     three_wxs_handle.write_all(three_wxs.as_bytes()).unwrap();
     package
+}
+
+/// Create a new cargo workspace with multiple sub-projects in a
+/// temporary directory. See the [create_test_package] function for more
+/// information.
+pub fn create_test_workspace() -> TempDir {
+    let temp_dir = TempDir::new().unwrap();
+    fs::create_dir(temp_dir.path().join(SUBPACKAGE1_NAME)).unwrap();
+    fs::create_dir(temp_dir.path().join(SUBPACKAGE2_NAME)).unwrap();
+    create_test_package_at_path(&temp_dir.path().join(SUBPACKAGE1_NAME), SUBPACKAGE1_NAME);
+    create_test_package_at_path(&temp_dir.path().join(SUBPACKAGE2_NAME), SUBPACKAGE2_NAME);
+	fs::write(temp_dir.path().join("Cargo.toml"), format!(r#"[workspace]
+	members = [{:?}, {:?}]"#, SUBPACKAGE1_NAME, SUBPACKAGE2_NAME)).unwrap();
+    temp_dir.into_persistent_if(env::var(PERSIST_VAR_NAME).is_ok())
 }
 
 /// Evaluates an XPath expression for a WiX Source file.

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -225,8 +225,15 @@ pub fn create_test_workspace() -> TempDir {
     fs::create_dir(temp_dir.path().join(SUBPACKAGE2_NAME)).unwrap();
     create_test_package_at_path(&temp_dir.path().join(SUBPACKAGE1_NAME), SUBPACKAGE1_NAME);
     create_test_package_at_path(&temp_dir.path().join(SUBPACKAGE2_NAME), SUBPACKAGE2_NAME);
-	fs::write(temp_dir.path().join("Cargo.toml"), format!(r#"[workspace]
-	members = [{:?}, {:?}]"#, SUBPACKAGE1_NAME, SUBPACKAGE2_NAME)).unwrap();
+    fs::write(
+        temp_dir.path().join("Cargo.toml"),
+        format!(
+            r#"[workspace]
+            members = [{:?}, {:?}]"#,
+            SUBPACKAGE1_NAME, SUBPACKAGE2_NAME
+        ),
+    )
+    .unwrap();
     temp_dir.into_persistent_if(env::var(PERSIST_VAR_NAME).is_ok())
 }
 

--- a/tests/create.rs
+++ b/tests/create.rs
@@ -49,16 +49,14 @@ lazy_static! {
 
 lazy_static! {
     static ref TARGET_NAME: PathBuf = {
-        let tmp = std::env::temp_dir();
-        tmp.join("wix_target/");
-        tmp
+        PathBuf::from("target")
     };
 }
-
 /// Run the _create_ subcommand with the output capture toggled by the
 /// `CARGO_WIX_TEST_NO_CAPTURE` environment variable.
 fn run(b: &mut Builder) -> Result<()> {
-    env::set_var("CARGO_TARGET_DIR", &*TARGET_NAME);
+    // Forcefully set the target dir to its default location
+    env::set_var("CARGO_TARGET_DIR", "target");
     b.capture_output(env::var(NO_CAPTURE_VAR_NAME).is_err())
         .build()
         .run()

--- a/tests/create.rs
+++ b/tests/create.rs
@@ -50,9 +50,7 @@ lazy_static! {
 }
 
 lazy_static! {
-    static ref TARGET_NAME: PathBuf = {
-        PathBuf::from("target")
-    };
+    static ref TARGET_NAME: PathBuf = { PathBuf::from("target") };
 }
 /// Run the _create_ subcommand with the output capture toggled by the
 /// `CARGO_WIX_TEST_NO_CAPTURE` environment variable.
@@ -922,11 +920,11 @@ fn compiler_and_linker_args_works_with_metadata() {
         .assert(predicate::path::exists());
 }
 
-
 #[test]
 fn custom_target_dir_works() {
     init_logging();
-    let target_tmpdir = TempDir::new().unwrap()
+    let target_tmpdir = TempDir::new()
+        .unwrap()
         .into_persistent_if(env::var(PERSIST_VAR_NAME).is_ok());
 
     let original_working_directory = env::current_dir().unwrap();
@@ -941,9 +939,7 @@ fn custom_target_dir_works() {
         .run();
     env::set_current_dir(original_working_directory).unwrap();
     result.expect("OK result");
-    target_tmpdir
-        .child(WIX)
-        .assert(predicate::path::exists());
+    target_tmpdir.child(WIX).assert(predicate::path::exists());
     target_tmpdir
         .child(expected_msi_file)
         .assert(predicate::path::exists());

--- a/tests/create.rs
+++ b/tests/create.rs
@@ -26,7 +26,7 @@ use assert_fs::prelude::*;
 use predicates::prelude::*;
 
 use crate::common::init_logging;
-use crate::common::{MISC_NAME, NO_CAPTURE_VAR_NAME, PACKAGE_NAME, TARGET_NAME};
+use crate::common::{MISC_NAME, NO_CAPTURE_VAR_NAME, PACKAGE_NAME};
 
 use std::env;
 use std::fs::{self, File};
@@ -41,15 +41,24 @@ use wix::{Result, CARGO_MANIFEST_FILE, WIX};
 
 lazy_static! {
     static ref TARGET_WIX_DIR: PathBuf = {
-        let mut p = PathBuf::from(TARGET_NAME);
+        let mut p = TARGET_NAME.clone();
         p.push(WIX);
         p
+    };
+}
+
+lazy_static! {
+    static ref TARGET_NAME: PathBuf = {
+        let tmp = std::env::temp_dir();
+        tmp.join("wix_target/");
+        tmp
     };
 }
 
 /// Run the _create_ subcommand with the output capture toggled by the
 /// `CARGO_WIX_TEST_NO_CAPTURE` environment variable.
 fn run(b: &mut Builder) -> Result<()> {
+    env::set_var("CARGO_TARGET_DIR", &*TARGET_NAME);
     b.capture_output(env::var(NO_CAPTURE_VAR_NAME).is_err())
         .build()
         .run()
@@ -153,7 +162,7 @@ fn metadata_works() {
 #[test]
 fn output_trailing_forwardslash_works() {
     init_logging();
-    let output_dir = PathBuf::from(TARGET_NAME).join("output_dir");
+    let output_dir = TARGET_NAME.join("output_dir");
     let output_dir_str = format!("{}/", output_dir.to_str().unwrap());
     let original_working_directory = env::current_dir().unwrap();
     let package = common::create_test_package();
@@ -174,7 +183,7 @@ fn output_trailing_forwardslash_works() {
 #[test]
 fn output_trailing_backslash_works() {
     init_logging();
-    let output_dir = PathBuf::from(TARGET_NAME).join("output_dir");
+    let output_dir = TARGET_NAME.join("output_dir");
     let output_dir_str = format!("{}\\", output_dir.to_str().unwrap());
     let original_working_directory = env::current_dir().unwrap();
     let package = common::create_test_package();
@@ -216,7 +225,7 @@ fn output_existing_dir_works() {
 #[test]
 fn output_file_without_extension_works() {
     init_logging();
-    let output_dir = PathBuf::from(TARGET_NAME).join("output_dir");
+    let output_dir = TARGET_NAME.join("output_dir");
     let original_working_directory = env::current_dir().unwrap();
     let package = common::create_test_package();
     let output_file = output_dir.join(PACKAGE_NAME);
@@ -237,7 +246,7 @@ fn output_file_without_extension_works() {
 #[test]
 fn output_file_with_extension_works() {
     init_logging();
-    let output_dir = PathBuf::from(TARGET_NAME).join("output_dir");
+    let output_dir = TARGET_NAME.join("output_dir");
     let original_working_directory = env::current_dir().unwrap();
     let package = common::create_test_package();
     let expected_msi_file = output_dir.join(format!("{}.msi", PACKAGE_NAME));

--- a/tests/create.rs
+++ b/tests/create.rs
@@ -55,8 +55,15 @@ lazy_static! {
 /// Run the _create_ subcommand with the output capture toggled by the
 /// `CARGO_WIX_TEST_NO_CAPTURE` environment variable.
 fn run(b: &mut Builder) -> Result<()> {
+    run_with_package(b, &std::env::current_dir()?)
+}
+
+/// Run the _create_ subcommand with the output capture toggled by the
+/// `CARGO_WIX_TEST_NO_CAPTURE` environment variable, and the CARGO_TARGET_DIR
+/// env variable set to <package path>/target.
+fn run_with_package(b: &mut Builder, package_path: &Path) -> Result<()> {
     // Forcefully set the target dir to its default location
-    env::set_var("CARGO_TARGET_DIR", "target");
+    env::set_var("CARGO_TARGET_DIR", package_path.join("target"));
     b.capture_output(env::var(NO_CAPTURE_VAR_NAME).is_err())
         .build()
         .run()
@@ -757,7 +764,7 @@ fn input_works_outside_cwd() {
         .build()
         .run()
         .unwrap();
-    let result = run(Builder::default().input(package_manifest.path().to_str()));
+    let result = run_with_package(Builder::default().input(package_manifest.path().to_str()), &package.path());
     result.expect("OK result");
     package
         .child(TARGET_WIX_DIR.as_path())

--- a/tests/create.rs
+++ b/tests/create.rs
@@ -926,8 +926,8 @@ fn compiler_and_linker_args_works_with_metadata() {
 #[test]
 fn custom_target_dir_works() {
     init_logging();
-    std::env::set_var("CARGO_TARGET_DIR", "my-target");
     let original_working_directory = env::current_dir().unwrap();
+    std::env::set_var("CARGO_TARGET_DIR", original_working_directory.join("my-target"));
     let package = common::create_test_package();
     let expected_msi_file = PathBuf::from("my-target").join(format!("{}-1.1.0-x86_64.msi", PACKAGE_NAME));
     env::set_current_dir(package.path()).unwrap();
@@ -936,7 +936,7 @@ fn custom_target_dir_works() {
     env::set_current_dir(original_working_directory).unwrap();
     result.expect("OK result");
     package
-        .child(PathBuf::from("my-target/wix"))
+        .child(PathBuf::from("my-target").join("wix"))
         .assert(predicate::path::exists());
     package
         .child(expected_msi_file)

--- a/tests/create.rs
+++ b/tests/create.rs
@@ -766,7 +766,8 @@ fn input_works_outside_cwd() {
         .unwrap();
     let result = run_with_package(
         Builder::default().input(package_manifest.path().to_str()),
-        &package.path());
+        &package.path(),
+    );
     result.expect("OK result");
     package
         .child(TARGET_WIX_DIR.as_path())

--- a/tests/create.rs
+++ b/tests/create.rs
@@ -26,7 +26,7 @@ use assert_fs::prelude::*;
 use predicates::prelude::*;
 
 use crate::common::init_logging;
-use crate::common::{MISC_NAME, NO_CAPTURE_VAR_NAME, PACKAGE_NAME, PERSIST_VAR_NAME};
+use crate::common::{MISC_NAME, NO_CAPTURE_VAR_NAME, PACKAGE_NAME, SUBPACKAGE1_NAME, PERSIST_VAR_NAME};
 
 use assert_fs::TempDir;
 
@@ -951,6 +951,25 @@ fn custom_target_dir_works() {
     result.expect("OK result");
     target_tmpdir.child(WIX).assert(predicate::path::exists());
     target_tmpdir
+        .child(expected_msi_file)
+        .assert(predicate::path::exists());
+}
+
+#[test]
+fn workspace_package_works() {
+    init_logging();
+    let original_working_directory = env::current_dir().unwrap();
+    let package = common::create_test_workspace();
+    let expected_msi_file = TARGET_WIX_DIR.join(format!("{}-0.1.0-x86_64.msi", SUBPACKAGE1_NAME));
+    env::set_current_dir(package.path()).unwrap();
+    initialize::Builder::new().package(Some(SUBPACKAGE1_NAME)).build().run().unwrap();
+    let result = run(&mut Builder::default().package(Some(SUBPACKAGE1_NAME)));
+    env::set_current_dir(original_working_directory).unwrap();
+    result.expect("OK result");
+    package
+        .child(TARGET_WIX_DIR.as_path())
+        .assert(predicate::path::exists());
+    package
         .child(expected_msi_file)
         .assert(predicate::path::exists());
 }

--- a/tests/create.rs
+++ b/tests/create.rs
@@ -764,7 +764,9 @@ fn input_works_outside_cwd() {
         .build()
         .run()
         .unwrap();
-    let result = run_with_package(Builder::default().input(package_manifest.path().to_str()), &package.path());
+    let result = run_with_package(
+        Builder::default().input(package_manifest.path().to_str()),
+        &package.path());
     result.expect("OK result");
     package
         .child(TARGET_WIX_DIR.as_path())

--- a/tests/create.rs
+++ b/tests/create.rs
@@ -26,7 +26,9 @@ use assert_fs::prelude::*;
 use predicates::prelude::*;
 
 use crate::common::init_logging;
-use crate::common::{MISC_NAME, NO_CAPTURE_VAR_NAME, PACKAGE_NAME, SUBPACKAGE1_NAME, PERSIST_VAR_NAME};
+use crate::common::{
+    MISC_NAME, NO_CAPTURE_VAR_NAME, PACKAGE_NAME, PERSIST_VAR_NAME, SUBPACKAGE1_NAME,
+};
 
 use assert_fs::TempDir;
 
@@ -962,7 +964,11 @@ fn workspace_package_works() {
     let package = common::create_test_workspace();
     let expected_msi_file = TARGET_WIX_DIR.join(format!("{}-0.1.0-x86_64.msi", SUBPACKAGE1_NAME));
     env::set_current_dir(package.path()).unwrap();
-    initialize::Builder::new().package(Some(SUBPACKAGE1_NAME)).build().run().unwrap();
+    initialize::Builder::new()
+        .package(Some(SUBPACKAGE1_NAME))
+        .build()
+        .run()
+        .unwrap();
     let result = run(&mut Builder::default().package(Some(SUBPACKAGE1_NAME)));
     env::set_current_dir(original_working_directory).unwrap();
     result.expect("OK result");

--- a/tests/create.rs
+++ b/tests/create.rs
@@ -936,7 +936,7 @@ fn custom_target_dir_works() {
     env::set_current_dir(original_working_directory).unwrap();
     result.expect("OK result");
     package
-        .child(TARGET_WIX_DIR.as_path())
+        .child(PathBuf::from("my-target/wix"))
         .assert(predicate::path::exists());
     package
         .child(expected_msi_file)

--- a/tests/create.rs
+++ b/tests/create.rs
@@ -912,3 +912,24 @@ fn compiler_and_linker_args_works_with_metadata() {
         .child(expected_msi_file)
         .assert(predicate::path::exists());
 }
+
+
+#[test]
+fn custom_target_dir_works() {
+    init_logging();
+    std::env::set_var("CARGO_TARGET_DIR", "my-target");
+    let original_working_directory = env::current_dir().unwrap();
+    let package = common::create_test_package();
+    let expected_msi_file = PathBuf::from("my-target").join(format!("{}-1.1.0-x86_64.msi", PACKAGE_NAME));
+    env::set_current_dir(package.path()).unwrap();
+    initialize::Execution::default().run().unwrap();
+    let result = run(&mut Builder::default());
+    env::set_current_dir(original_working_directory).unwrap();
+    result.expect("OK result");
+    package
+        .child(TARGET_WIX_DIR.as_path())
+        .assert(predicate::path::exists());
+    package
+        .child(expected_msi_file)
+        .assert(predicate::path::exists());
+}

--- a/tests/initialize.rs
+++ b/tests/initialize.rs
@@ -729,11 +729,11 @@ fn product_icon_works() {
 #[test]
 fn multiple_binaries_works() {
     const EXPECTED_NAME_1: &str = "main1";
-    const EXPECTED_SOURCE_1: &str = "target\\$(var.Profile)\\main1.exe";
+    const EXPECTED_SOURCE_1: &str = "$(var.CargoTargetDir)\\$(var.Profile)\\main1.exe";
     const EXPECTED_NAME_2: &str = "main2";
-    const EXPECTED_SOURCE_2: &str = "target\\$(var.Profile)\\main2.exe";
+    const EXPECTED_SOURCE_2: &str = "$(var.CargoTargetDir)\\$(var.Profile)\\main2.exe";
     const EXPECTED_NAME_3: &str = "main3";
-    const EXPECTED_SOURCE_3: &str = "target\\$(var.Profile)\\main3.exe";
+    const EXPECTED_SOURCE_3: &str = "$(var.CargoTargetDir)\\$(var.Profile)\\main3.exe";
     let original_working_directory = env::current_dir().unwrap();
     let package = common::create_test_package_multiple_binaries();
     env::set_current_dir(package.path()).unwrap();

--- a/tests/initialize.rs
+++ b/tests/initialize.rs
@@ -788,6 +788,7 @@ fn multiple_binaries_works() {
 
 #[test]
 fn workspace_no_package_fails() {
+    init_logging();
     let original_working_directory = env::current_dir().unwrap();
     let package = common::create_test_workspace();
     env::set_current_dir(package.path()).unwrap();
@@ -798,6 +799,7 @@ fn workspace_no_package_fails() {
 
 #[test]
 fn workspace_package_works() {
+    init_logging();
     let original_working_directory = env::current_dir().unwrap();
     let package = common::create_test_workspace();
     env::set_current_dir(package.path()).unwrap();

--- a/tests/initialize.rs
+++ b/tests/initialize.rs
@@ -33,7 +33,7 @@ use toml::Value;
 use wix::initialize::{Builder, Execution};
 use wix::{
     CARGO_MANIFEST_FILE, LICENSE_FILE_NAME, RTF_FILE_EXTENSION, WIX, WIX_SOURCE_FILE_EXTENSION,
-    WIX_SOURCE_FILE_NAME
+    WIX_SOURCE_FILE_NAME,
 };
 
 use crate::common::{init_logging, SUBPACKAGE1_NAME};
@@ -791,9 +791,7 @@ fn workspace_no_package_fails() {
     let original_working_directory = env::current_dir().unwrap();
     let package = common::create_test_workspace();
     env::set_current_dir(package.path()).unwrap();
-    let result = Builder::default()
-        .build()
-        .run();
+    let result = Builder::default().build().run();
     env::set_current_dir(original_working_directory).unwrap();
     assert!(result.is_err());
 }

--- a/tests/initialize.rs
+++ b/tests/initialize.rs
@@ -36,7 +36,7 @@ use wix::{
     WIX_SOURCE_FILE_NAME
 };
 
-use crate::common::SUBPACKAGE1_NAME;
+use crate::common::{init_logging, SUBPACKAGE1_NAME};
 
 lazy_static! {
     static ref MAIN_WXS: String = WIX_SOURCE_FILE_NAME.to_owned() + "." + WIX_SOURCE_FILE_EXTENSION;


### PR DESCRIPTION
## Preface

This is a bit of a big PR, and the commits are currently a mess. I'm sorry.

## Motivation

Currently, cargo wix manually parses TOML files, and tries to guess what the compiler is going to do based on this. This leads to a lot of issues: It doesn't properly support [custom target directories](https://doc.rust-lang.org/cargo/reference/config.html#buildtarget-dir), it [fails to work in workspaces](https://github.com/volks73/cargo-wix/issues/74), it doesn't support cross-compilation (for instance to build 32-bit targets from a 64-bit host), it fails to find binaries under `src/bin/*.rs`. I'm sure there are more issues, but those are the ones I identified while trying to use cargo-wix in my own project.

Most of those issues could be fixed by asking cargo for the information we seek directly, instead of trying to guess them. This is exactly what the `cargo metadata` subcommand does: it allows us to query cargo for the metadata of a given project, for instance what packages are in the current workspace, which binaries that package contains, where those binaries will be built, etc...

## Details

This PR does a few things:

First of all, it moves as much of the manual TOML parsing as possible to a call to cargo-metadata. If the current workspace has only one package, it will use this one, otherwise it requires the user to pass the package name via a command line parameter (`--package`).

Second, it uses the information from cargo-metadata to find *all* the binaries, including those in `src/bin`. Cargo is nice enough to give us all the implicit and explicit bin targets!

Third it removes all the hardcoded paths to `target/`. `cargo-wix` now injects a wix preprocessor variable, CargoTargetDir, that is set to the proper target directory (as found by cargo-metadata). The templates are updated to automatically use this variable.

## TODO

- [x] Find a way to get the homepage. Cargo metadata doesn't provide it - we might need to parse the TOML to get that value :(.
     EDIT: I submitted a cargo PR to surface those values: https://github.com/rust-lang/cargo/pull/8744. If/when this is merged, this will need to be followed by a PR to the `cargo_metadata` project. This will likely take a bit. In the meantime, I guess we could manually parse the TOML just to get this field.
- [x] Add a --package arg to all the subcommands
- [x] Add tests for --package
- [ ] Add tests for multi-bin projects