### PR TITLE
First stab at cross-compilation support

### DIFF
--- a/src/create.rs
+++ b/src/create.rs
@@ -921,8 +921,8 @@ impl Execution {
     /// Gets the target used to compile the binary. This will either return the
     /// target passed as an argument, or find it from rustc's HOST triple.
     // NOTE: This does not support default-target. Ideally we would use cargo
-    // --build-plan to figure this out without having to second-guess the
-    // compiler. Unfortunately, cargo build-plan is unstable.
+    // --unit-graph to figure this out without having to second-guess the
+    // compiler. Unfortunately, cargo --unit-graph is unstable.
     fn target(&self) -> Result<String> {
         match &self.target {
             Some(v) => Ok(v.clone()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1362,6 +1362,13 @@ fn main() {
                     .multiple(true)
                     .number_of_values(1)
                     .allow_hyphen_values(true))
+                .arg(Arg::with_name("target")
+                    .help("The cargo target to build the WiX installer for.")
+                    .long_help("Tells cargo to build the given target, and instructs \
+                        WiX to build an installer targeting the right architecture.")
+                    .long("target")
+                    .short("t")
+                    .takes_value(true))
                 .arg(Arg::with_name("debug-build")
                     .help("Builds the package using the Debug profile")
                     .long_help("Uses the Debug profile when building the package \
@@ -1788,6 +1795,7 @@ fn main() {
             create.output(matches.value_of("output"));
             create.version(matches.value_of("install-version"));
             create.package(matches.value_of("package"));
+            create.target(matches.value_of("target"));
             create.build().run()
         }
     };

--- a/src/print/wxs.rs
+++ b/src/print/wxs.rs
@@ -475,10 +475,7 @@ impl Execution {
     }
 
     fn default_binary_path(name: &str) -> String {
-        let mut path = Path::new("$(var.CargoTargetDir)")
-            .join("$(var.CargoTargetPathName)")
-            .join("$(var.Profile)")
-            .join(name);
+        let mut path = Path::new("$(var.CargoTargetBinDir)").join(name);
         path.set_extension(EXE_FILE_EXTENSION);
         path.to_str()
             .map(String::from)
@@ -979,7 +976,7 @@ mod tests {
                 vec![hashmap! {
                     "binary-index" => 0.to_string(),
                     "binary-name" => String::from("Example"),
-                    "binary-source" => String::from("$(var.CargoTargetDir)\\$(var.CargoTargetPathName)\\$(var.Profile)\\Example.exe")
+                    "binary-source" => String::from("$(var.CargoTargetBinDir)\\Example.exe")
                 }]
             )
         }
@@ -996,7 +993,7 @@ mod tests {
                 vec![hashmap! {
                     "binary-index" => 0.to_string(),
                     "binary-name" => String::from("Different"),
-                    "binary-source" => String::from("$(var.CargoTargetDir)\\$(var.CargoTargetPathName)\\$(var.Profile)\\Different.exe")
+                    "binary-source" => String::from("$(var.CargoTargetBinDir)\\Different.exe")
                 }]
             )
         }
@@ -1014,17 +1011,17 @@ mod tests {
                     hashmap! {
                         "binary-index" => 0.to_string(),
                         "binary-name" => String::from("binary0"),
-                        "binary-source" => String::from("$(var.CargoTargetDir)\\$(var.CargoTargetPathName)\\$(var.Profile)\\binary0.exe")
+                        "binary-source" => String::from("$(var.CargoTargetBinDir)\\binary0.exe")
                     },
                     hashmap! {
                         "binary-index" => 1.to_string(),
                         "binary-name" => String::from("binary1"),
-                        "binary-source" => String::from("$(var.CargoTargetDir)\\$(var.CargoTargetPathName)\\$(var.Profile)\\binary1.exe")
+                        "binary-source" => String::from("$(var.CargoTargetBinDir)\\binary1.exe")
                     },
                     hashmap! {
                         "binary-index" => 2.to_string(),
                         "binary-name" => String::from("binary2"),
-                        "binary-source" => String::from("$(var.CargoTargetDir)\\$(var.CargoTargetPathName)\\$(var.Profile)\\binary2.exe")
+                        "binary-source" => String::from("$(var.CargoTargetBinDir)\\binary2.exe")
                     }
                 ]
             )

--- a/src/print/wxs.rs
+++ b/src/print/wxs.rs
@@ -475,8 +475,8 @@ impl Execution {
     }
 
     fn default_binary_path(name: &str) -> String {
-        // TODO: Handle cross-compilation?
         let mut path = Path::new("$(var.CargoTargetDir)")
+            .join("$(var.CargoTargetPathName)")
             .join("$(var.Profile)")
             .join(name);
         path.set_extension(EXE_FILE_EXTENSION);
@@ -979,7 +979,7 @@ mod tests {
                 vec![hashmap! {
                     "binary-index" => 0.to_string(),
                     "binary-name" => String::from("Example"),
-                    "binary-source" => String::from("$(var.CargoTargetDir)\\$(var.Profile)\\Example.exe")
+                    "binary-source" => String::from("$(var.CargoTargetDir)\\$(var.CargoTargetPathName)\\$(var.Profile)\\Example.exe")
                 }]
             )
         }
@@ -996,7 +996,7 @@ mod tests {
                 vec![hashmap! {
                     "binary-index" => 0.to_string(),
                     "binary-name" => String::from("Different"),
-                    "binary-source" => String::from("$(var.CargoTargetDir)\\$(var.Profile)\\Different.exe")
+                    "binary-source" => String::from("$(var.CargoTargetDir)\\$(var.CargoTargetPathName)\\$(var.Profile)\\Different.exe")
                 }]
             )
         }
@@ -1014,17 +1014,17 @@ mod tests {
                     hashmap! {
                         "binary-index" => 0.to_string(),
                         "binary-name" => String::from("binary0"),
-                        "binary-source" => String::from("$(var.CargoTargetDir)\\$(var.Profile)\\binary0.exe")
+                        "binary-source" => String::from("$(var.CargoTargetDir)\\$(var.CargoTargetPathName)\\$(var.Profile)\\binary0.exe")
                     },
                     hashmap! {
                         "binary-index" => 1.to_string(),
                         "binary-name" => String::from("binary1"),
-                        "binary-source" => String::from("$(var.CargoTargetDir)\\$(var.Profile)\\binary1.exe")
+                        "binary-source" => String::from("$(var.CargoTargetDir)\\$(var.CargoTargetPathName)\\$(var.Profile)\\binary1.exe")
                     },
                     hashmap! {
                         "binary-index" => 2.to_string(),
                         "binary-name" => String::from("binary2"),
-                        "binary-source" => String::from("$(var.CargoTargetDir)\\$(var.Profile)\\binary2.exe")
+                        "binary-source" => String::from("$(var.CargoTargetDir)\\$(var.CargoTargetPathName)\\$(var.Profile)\\binary2.exe")
                     }
                 ]
             )

--- a/src/templates/main.wxs.mustache
+++ b/src/templates/main.wxs.mustache
@@ -27,12 +27,6 @@
     <?define PlatformProgramFilesFolder = "ProgramFilesFolder" ?>
 <?endif ?>
 
-<?ifdef CargoTargetExplicit ?>
-    <?define CargoTargetPathName = "$(var.CargoTarget)" ?>
-<?else ?>
-    <?define CargoTargetPathName = "" ?>
-<?endif ?>
-
 <Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
 
     <Product

--- a/src/templates/main.wxs.mustache
+++ b/src/templates/main.wxs.mustache
@@ -21,12 +21,16 @@
   destination for 32-bit versus 64-bit installers. Removal of these lines will
   cause installation errors.
 -->
-<?if $(var.Platform) = x64 ?>
-    <?define Win64 = "yes" ?>
+<?if $(sys.BUILDARCH) = x64 or $(sys.BUILDARCH) = arm64 ?>
     <?define PlatformProgramFilesFolder = "ProgramFiles64Folder" ?>
 <?else ?>
-  <?define Win64 = "no" ?>
-  <?define PlatformProgramFilesFolder = "ProgramFilesFolder" ?>
+    <?define PlatformProgramFilesFolder = "ProgramFilesFolder" ?>
+<?endif ?>
+
+<?ifdef CargoTargetExplicit ?>
+    <?define CargoTargetPathName = "$(var.CargoTarget)" ?>
+<?else ?>
+    <?define CargoTargetPathName = "" ?>
 <?endif ?>
 
 <Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
@@ -51,7 +55,7 @@
             Compressed='yes'
             InstallScope='perMachine'
             SummaryCodepage='1252'
-            Platform='$(var.Platform)'/>
+            />
 
         <MajorUpgrade
             Schedule='afterInstallInitialize'
@@ -71,7 +75,7 @@
                       2. Comment out or remove the `ComponentRef` tag with the "License" Id
                          attribute value further down in this file.
                     -->
-                    <Component Id='License' Guid='*' Win64='$(var.Win64)'>
+                    <Component Id='License' Guid='*'>
                         <File Id='LicenseFile'
                             {{#license-name}}
                             Name='{{license-name}}'
@@ -97,14 +101,14 @@
                          further down in this file.
                     -->
                     <!--
-                    <Component Id='License' Guid='*' Win64='$(var.Win64)'>
+                    <Component Id='License' Guid='*'>
                         <File Id='LicenseFile' Name='ChangeMe' DiskId='1' Source='C:\Path\To\File' KeyPath='yes'/>
                     </Component>
                     -->
                     {{/license-source}}
 
                     <Directory Id='Bin' Name='bin'>
-                        <Component Id='Path' Guid='{{path-component-guid}}' Win64='$(var.Win64)' KeyPath='yes'>
+                        <Component Id='Path' Guid='{{path-component-guid}}' KeyPath='yes'>
                             <Environment
                                 Id='PATH'
                                 Name='PATH'
@@ -115,7 +119,7 @@
                                 System='yes'/>
                         </Component>
                         {{#binaries}}
-                        <Component Id='binary{{binary-index}}' Guid='*' Win64='$(var.Win64)'>
+                        <Component Id='binary{{binary-index}}' Guid='*'>
                             <File
                                 Id='exe{{binary-index}}'
                                 Name='{{binary-name}}.exe'

--- a/tests/common/two.wxs
+++ b/tests/common/two.wxs
@@ -1,8 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?if $(sys.BUILDARCH) = x64 or $(sys.BUILDARCH) = arm64 ?>
+    <?define PlatformProgramFilesFolder = "ProgramFiles64Folder" ?>
+<?else ?>
+    <?define PlatformProgramFilesFolder = "ProgramFilesFolder" ?>
+<?endif ?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
   <Fragment>
     <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="ProgramFilesFolder">
+      <Directory Id="$(var.PlatformProgramFilesFolder)">
         <Directory Id="INSTALLFOLDER" Name="My Software" />
       </Directory>
     </Directory>

--- a/tests/create.rs
+++ b/tests/create.rs
@@ -980,3 +980,22 @@ fn workspace_package_works() {
         .child(expected_msi_file)
         .assert(predicate::path::exists());
 }
+
+#[test]
+fn cross_compilation_works() {
+    init_logging();
+    let original_working_directory = env::current_dir().unwrap();
+    let package = common::create_test_package();
+    let expected_msi_file = TARGET_WIX_DIR.join(format!("{}-0.1.0-x86_64.msi", PACKAGE_NAME));
+    env::set_current_dir(package.path()).unwrap();
+    initialize::Execution::default().run().unwrap();
+    let result = run(&mut Builder::default().target(Some("x86_64-pc-windows-msvc")));
+    env::set_current_dir(original_working_directory).unwrap();
+    result.expect("OK result");
+    package
+        .child(TARGET_WIX_DIR.as_path())
+        .assert(predicate::path::exists());
+    package
+        .child(expected_msi_file)
+        .assert(predicate::path::exists());
+}

--- a/tests/initialize.rs
+++ b/tests/initialize.rs
@@ -731,11 +731,14 @@ fn product_icon_works() {
 #[test]
 fn multiple_binaries_works() {
     const EXPECTED_NAME_1: &str = "main1";
-    const EXPECTED_SOURCE_1: &str = "$(var.CargoTargetDir)\\$(var.Profile)\\main1.exe";
+    const EXPECTED_SOURCE_1: &str =
+        "$(var.CargoTargetDir)\\$(var.CargoTargetPathName)\\$(var.Profile)\\main1.exe";
     const EXPECTED_NAME_2: &str = "main2";
-    const EXPECTED_SOURCE_2: &str = "$(var.CargoTargetDir)\\$(var.Profile)\\main2.exe";
+    const EXPECTED_SOURCE_2: &str =
+        "$(var.CargoTargetDir)\\$(var.CargoTargetPathName)\\$(var.Profile)\\main2.exe";
     const EXPECTED_NAME_3: &str = "main3";
-    const EXPECTED_SOURCE_3: &str = "$(var.CargoTargetDir)\\$(var.Profile)\\main3.exe";
+    const EXPECTED_SOURCE_3: &str =
+        "$(var.CargoTargetDir)\\$(var.CargoTargetPathName)\\$(var.Profile)\\main3.exe";
     let original_working_directory = env::current_dir().unwrap();
     let package = common::create_test_package_multiple_binaries();
     env::set_current_dir(package.path()).unwrap();

--- a/tests/initialize.rs
+++ b/tests/initialize.rs
@@ -731,14 +731,11 @@ fn product_icon_works() {
 #[test]
 fn multiple_binaries_works() {
     const EXPECTED_NAME_1: &str = "main1";
-    const EXPECTED_SOURCE_1: &str =
-        "$(var.CargoTargetDir)\\$(var.CargoTargetPathName)\\$(var.Profile)\\main1.exe";
+    const EXPECTED_SOURCE_1: &str = "$(var.CargoTargetBinDir)\\main1.exe";
     const EXPECTED_NAME_2: &str = "main2";
-    const EXPECTED_SOURCE_2: &str =
-        "$(var.CargoTargetDir)\\$(var.CargoTargetPathName)\\$(var.Profile)\\main2.exe";
+    const EXPECTED_SOURCE_2: &str = "$(var.CargoTargetBinDir)\\main2.exe";
     const EXPECTED_NAME_3: &str = "main3";
-    const EXPECTED_SOURCE_3: &str =
-        "$(var.CargoTargetDir)\\$(var.CargoTargetPathName)\\$(var.Profile)\\main3.exe";
+    const EXPECTED_SOURCE_3: &str = "$(var.CargoTargetBinDir)\\main3.exe";
     let original_working_directory = env::current_dir().unwrap();
     let package = common::create_test_package_multiple_binaries();
     env::set_current_dir(package.path()).unwrap();


### PR DESCRIPTION
My first stab at fixing #110. Not fully complete yet (need to integrate it into the CLI, write some tests, fix some others).

This PR works by adding a new optional target flag to the Create step, which contains the rust target to build for. This flag is passed as-is to the cargo invocation.

When invoking wix, we use the target to find which `-arch` to pass to wix. This is currently implemented by looking at the first component of the target name, and transforming it to something wix-compatible (e.g. "x86_64" => "x64", etc...). Note that this is somewhat wrong: Ideally we should extract the target spec from `rustc -Z unstable-options --print target-spec-json | jq .llvm-target`, but the target spec json isn't stable, so we can't easily rely on it. Using the target name is an OK approximation that should get us most of the way there.

We then pass the target name to Wix as a variable, so we can find where the resulting binaries go.

I took the opportunity to remove use of Win64 and Platform in the wxs: those attributes are deprecated according to the wix documentation, passing -arch on the command line should be prefered (which this PR now does). `var.Platform` is replaced by `sys.BUILDARCH`.