### PR TITLE
Support to run MSI installer after creating it

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ A different WiX Source (wxs) file from the `wix\main.wxs` file can be used by sp
 C:\Path\to\Project> cargo wix Path\to\WiX\Source\File.wxs
 ```
 
+You can also automatically run the installer after creating it by specifying the `--install` argument:
+
+```dos
+C:\Path\to\Project> cargo wix --install
+```
+
 The `print <template>` subcommand, which prints one of the embedded templates to stdout, can be used to create the `main.wxs` file. A [WXS template](https://github.com/volks73/cargo-wix/blob/master/src/main.wxs.mustache) file specifically designed to work with this subcommand is embedded within the `cargo-wix` binary during installation. Use the following commands to create a WiX Source file and use it to create an installer with this subcommand.
 
 ```dos

--- a/src/create.rs
+++ b/src/create.rs
@@ -29,8 +29,8 @@ use crate::WixArch;
 use crate::BINARY_FOLDER_NAME;
 use crate::CARGO;
 use crate::EXE_FILE_EXTENSION;
-use crate::MSI_FILE_EXTENSION;
 use crate::MSIEXEC;
+use crate::MSI_FILE_EXTENSION;
 use crate::WIX;
 use crate::WIX_COMPILER;
 use crate::WIX_LINKER;
@@ -640,9 +640,7 @@ impl Execution {
         // Launch the installer
         info!("Launching the installer");
         let mut installer = Command::new(MSIEXEC);
-        installer
-            .arg("/i")
-            .arg(&installer_destination);
+        installer.arg("/i").arg(&installer_destination);
         let status = installer.status()?;
         if !status.success() {
             return Err(Error::Command(

--- a/src/create.rs
+++ b/src/create.rs
@@ -638,17 +638,20 @@ impl Execution {
         }
 
         // Launch the installer
-        info!("Launching the installer");
-        let mut installer = Command::new(MSIEXEC);
-        installer.arg("/i").arg(&installer_destination);
-        let status = installer.status()?;
-        if !status.success() {
-            return Err(Error::Command(
-                MSIEXEC,
-                status.code().unwrap_or(100),
-                self.capture_output,
-            ));
+        if self.install {
+            info!("Launching the installer");
+            let mut installer = Command::new(MSIEXEC);
+            installer.arg("/i").arg(&installer_destination);
+            let status = installer.status()?;
+            if !status.success() {
+                return Err(Error::Command(
+                    MSIEXEC,
+                    status.code().unwrap_or(100),
+                    self.capture_output,
+                ));
+            }
         }
+
         Ok(())
     }
 

--- a/src/create.rs
+++ b/src/create.rs
@@ -30,6 +30,7 @@ use crate::BINARY_FOLDER_NAME;
 use crate::CARGO;
 use crate::EXE_FILE_EXTENSION;
 use crate::MSI_FILE_EXTENSION;
+use crate::MSIEXEC;
 use crate::WIX;
 use crate::WIX_COMPILER;
 use crate::WIX_LINKER;
@@ -71,6 +72,7 @@ pub struct Builder<'a> {
     locale: Option<&'a str>,
     name: Option<&'a str>,
     no_build: bool,
+    install: bool,
     output: Option<&'a str>,
     package: Option<&'a str>,
     target: Option<&'a str>,
@@ -93,6 +95,7 @@ impl<'a> Builder<'a> {
             locale: None,
             name: None,
             no_build: false,
+            install: false,
             output: None,
             package: None,
             target: None,
@@ -262,6 +265,19 @@ impl<'a> Builder<'a> {
         self
     }
 
+    /// Runs the installer after creating it.
+    ///
+    /// If `true`, the MSI installer will be created and then launched. This will
+    /// automatically open the installation wizard for the project and allow the
+    /// user to install it.
+    ///
+    /// This value will override any default and skip looking for a value in the
+    /// `[package.metadata.wix]` section of the package's manifest (Cargo.toml).
+    pub fn install(&mut self, n: bool) -> &mut Self {
+        self.install = n;
+        self
+    }
+
     /// Sets the output file and destination.
     ///
     /// The default is to create a MSI file with the
@@ -340,6 +356,7 @@ impl<'a> Builder<'a> {
             locale: self.locale.map(PathBuf::from),
             name: self.name.map(String::from),
             no_build: self.no_build,
+            install: self.install,
             output: self.output.map(String::from),
             package: self.package.map(String::from),
             version: self.version.map(String::from),
@@ -369,6 +386,7 @@ pub struct Execution {
     locale: Option<PathBuf>,
     name: Option<String>,
     no_build: bool,
+    install: bool,
     output: Option<String>,
     package: Option<String>,
     target: Option<String>,
@@ -391,6 +409,7 @@ impl Execution {
         debug!("self.locale = {:?}", self.locale);
         debug!("self.name = {:?}", self.name);
         debug!("self.no_build = {:?}", self.no_build);
+        debug!("self.install = {:?}", self.install);
         debug!("self.output = {:?}", self.output);
         debug!("self.package = {:?}", self.package);
         debug!("self.target = {:?}", self.target);
@@ -432,6 +451,7 @@ impl Execution {
         let cfg = Cfg::of(&target_triple).map_err(|e| Error::Generic(e.to_string()))?;
         let wix_arch = WixArch::try_from(&cfg)?;
         debug!("wix_arch = {:?}", wix_arch);
+
         if no_build {
             warn!("Skipped building the binary");
         } else {
@@ -468,6 +488,7 @@ impl Execution {
                 ));
             }
         }
+
         // Compile the installer
         info!("Compiling the installer");
         let mut compiler = self.compiler()?;
@@ -555,6 +576,7 @@ impl Execution {
             &manifest.target_directory,
         );
         debug!("installer_destination = {:?}", installer_destination);
+
         // Link the installer
         info!("Linking the installer");
         let mut linker = self.linker()?;
@@ -610,6 +632,21 @@ impl Execution {
         if !status.success() {
             return Err(Error::Command(
                 WIX_LINKER,
+                status.code().unwrap_or(100),
+                self.capture_output,
+            ));
+        }
+
+        // Launch the installer
+        info!("Launching the installer");
+        let mut installer = Command::new(MSIEXEC);
+        installer
+            .arg("/i")
+            .arg(&installer_destination);
+        let status = installer.status()?;
+        if !status.success() {
+            return Err(Error::Command(
+                MSIEXEC,
                 status.code().unwrap_or(100),
                 self.capture_output,
             ));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,6 +129,9 @@ pub const WIX_COMPILER: &str = "candle";
 /// Windows installer.
 pub const WIX_LINKER: &str = "light";
 
+/// The application name without the file extension of the `msiexec` utility.
+pub const MSIEXEC: &str = "msiexec";
+
 /// The file extension for a WiX Toolset object file, which is the output from
 /// the WiX compiler.
 pub const WIX_OBJECT_FILE_EXTENSION: &str = "wixobj";

--- a/src/main.rs
+++ b/src/main.rs
@@ -202,6 +202,13 @@
 //! is an artifact of the installer build process and can be ignored and/or
 //! deleted.
 //!
+//! You can also automatically run the installer after creating it by
+//! specifying the `--install` argument:
+//!
+//! ```dos
+//! C:\Path\to\Project> cargo wix --install
+//!  ```
+//!
 //! The installer that is created with the above steps and commands will install
 //! the `example.exe` file to: `C:\Program Files\example\bin\example.exe`. It
 //! will also add the `C:\Program Files\example\bin` path to the `PATH` system
@@ -1603,6 +1610,10 @@ fn main() {
                         for the binary and Windows installer, respectively. Use this \
                         flag to show the output.")
                     .long("nocapture"))
+                .arg(Arg::with_name("install")
+                    .help("Runs the installer after creating it")
+                    .long_help("Creates the installer and runs it after that.")
+                    .long("install"))
                 .arg(Arg::with_name("output")
                     .help("A path to a destination file or an existing folder")
                     .long_help("Sets the destination file name and path for the \
@@ -1888,6 +1899,7 @@ fn main() {
             create.locale(matches.value_of("locale"));
             create.name(matches.value_of("name"));
             create.no_build(matches.is_present("no-build"));
+            create.install(matches.is_present("install"));
             create.output(matches.value_of("output"));
             create.version(matches.value_of("install-version"));
             create.package(matches.value_of("package"));


### PR DESCRIPTION
This PR adds `--install` argument that can, when specified, automatically launch the installer after creating it. This closes #144.