### PR TITLE
Fix licenses workspaces

### DIFF
--- a/src/initialize.rs
+++ b/src/initialize.rs
@@ -470,6 +470,7 @@ impl Execution {
                     eula_printer.copyright_year(self.copyright_year.as_ref().map(String::as_ref));
                     eula_printer.input(self.input.as_deref().and_then(Path::to_str));
                     eula_printer.output(destination.as_path().to_str());
+                    eula_printer.package(self.package.as_deref());
                     eula_printer.build().run(template)?;
                 }
                 destination.pop();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1880,6 +1880,7 @@ fn main() {
                     print.copyright_year(m.value_of("year"));
                     print.input(m.value_of("INPUT"));
                     print.output(m.value_of("output"));
+                    print.package(m.value_of("package"));
                     print.build().run(t)
                 }
             }

--- a/src/print/license.rs
+++ b/src/print/license.rs
@@ -37,6 +37,7 @@ pub struct Builder<'a> {
     copyright_holder: Option<&'a str>,
     input: Option<&'a str>,
     output: Option<&'a str>,
+    package: Option<&'a str>,
 }
 
 impl<'a> Builder<'a> {
@@ -47,6 +48,7 @@ impl<'a> Builder<'a> {
             copyright_holder: None,
             input: None,
             output: None,
+            package: None,
         }
     }
 
@@ -95,6 +97,13 @@ impl<'a> Builder<'a> {
         self
     }
 
+    /// Sets the package.
+    ///
+    pub fn package(&mut self, o: Option<&'a str>) -> &mut Self {
+        self.package = o;
+        self
+    }
+
     /// Builds an execution context based on the configuration.
     pub fn build(&self) -> Execution {
         Execution {
@@ -102,6 +111,7 @@ impl<'a> Builder<'a> {
             copyright_year: self.copyright_year.map(String::from),
             input: self.input.map(PathBuf::from),
             output: self.output.map(PathBuf::from),
+            package: self.package.map(PathBuf::from),
         }
     }
 }
@@ -119,6 +129,7 @@ pub struct Execution {
     copyright_year: Option<String>,
     input: Option<PathBuf>,
     output: Option<PathBuf>,
+    package: Option<PathBuf>,
 }
 
 impl Execution {
@@ -129,7 +140,7 @@ impl Execution {
         debug!("input = {:?}", self.input);
         debug!("output = {:?}", self.output);
         let manifest = manifest(self.input.as_ref())?;
-        let package = package(&manifest, None)?;
+        let package = package(&manifest, self.package.as_ref().and_then(|p| p.to_str()))?;
         let mut destination = super::destination(self.output.as_ref())?;
         let template = mustache::compile_str(template.to_str())?;
         let data = MapBuilder::new()

--- a/tests/initialize.rs
+++ b/tests/initialize.rs
@@ -36,7 +36,7 @@ use wix::{
     WIX_SOURCE_FILE_NAME,
 };
 
-use crate::common::{init_logging, SUBPACKAGE1_NAME};
+use crate::common::{add_license_to_package, init_logging, SUBPACKAGE1_NAME, SUBPACKAGE2_NAME};
 
 lazy_static! {
     static ref MAIN_WXS: String = WIX_SOURCE_FILE_NAME.to_owned() + "." + WIX_SOURCE_FILE_EXTENSION;
@@ -843,4 +843,23 @@ fn workspace_package_works() {
         .child(SUBPACKAGE1_NAME)
         .child(LICENSE_RTF_PATH.as_path())
         .assert(predicate::path::missing());
+}
+
+#[test]
+#[serial]
+fn workspace_package_with_license_works() {
+    init_logging();
+    let original_working_directory = env::current_dir().unwrap();
+    let package = common::create_test_workspace();
+    add_license_to_package(&package.path().join(SUBPACKAGE1_NAME), "GPL-3.0");
+    add_license_to_package(&package.path().join(SUBPACKAGE2_NAME), "GPL-3.0");
+
+    env::set_current_dir(package.path()).unwrap();
+    let result = Builder::default()
+        .package(Some(SUBPACKAGE1_NAME))
+        .license(Some("license"))
+        .build()
+        .run();
+    env::set_current_dir(original_working_directory).unwrap();
+    assert!(result.is_ok());
 }


### PR DESCRIPTION
The license is always generated using a  `None` package with results in failing the initialization in workspaces environements.
This is due to:
```rust
 let package = package(&manifest, None)?;
```
This PR adds the `package` field to the license creation code path in order to forward the desired package option.
 