### PR TITLE
Add test cargo authors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: '1.50.0'
+          toolchain: 'stable'
           override: true
       - run: cargo test --all-targets
   rustfmt:
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: '1.50.0'
+          toolchain: 'stable'
           override: true
           components: rustfmt
       - run: cargo fmt --all -- --check
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: '1.50.0'
+          toolchain: 'stable'
           override: true
           components: clippy
       - run: cargo clippy --all-targets -- -D warnings

--- a/src/eula.rs
+++ b/src/eula.rs
@@ -39,7 +39,7 @@ impl Eula {
         if let Some(ref path) = p {
             Ok(Eula::CommandLine(path.into()))
         } else {
-            Eula::from_manifest(&package)
+            Eula::from_manifest(package)
         }
     }
 
@@ -79,7 +79,7 @@ impl Eula {
         } else if let Some(license_name) = package.license.as_ref() {
             trace!("The 'license' field is specified in the package's manifest (Cargo.toml)");
             debug!("license_name = {:?}", license_name);
-            if let Ok(template) = Template::from_str(&license_name) {
+            if let Ok(template) = Template::from_str(license_name) {
                 trace!(
                     "An embedded template for the '{}' license from the package's \
                      manifest (Cargo.toml) exists.",

--- a/src/print/license.rs
+++ b/src/print/license.rs
@@ -145,7 +145,7 @@ impl Execution {
         if let Some(ref h) = self.copyright_holder {
             Ok(h.to_owned())
         } else {
-            super::first_author(&manifest)
+            super::first_author(manifest)
         }
     }
 

--- a/src/print/wxs.rs
+++ b/src/print/wxs.rs
@@ -511,7 +511,7 @@ impl Execution {
             manifest
                 .license
                 .as_ref()
-                .filter(|l| Template::license_ids().contains(&l))
+                .filter(|l| Template::license_ids().contains(l))
                 .map(|_| String::from(LICENSE_FILE_NAME))
                 .or_else(|| {
                     manifest
@@ -528,7 +528,7 @@ impl Execution {
             manifest
                 .license
                 .as_ref()
-                .filter(|l| Template::license_ids().contains(&l))
+                .filter(|l| Template::license_ids().contains(l))
                 .map(|_| LICENSE_FILE_NAME.to_owned() + "." + RTF_FILE_EXTENSION)
                 .or_else(|| {
                     manifest.license_file().and_then(|s| {
@@ -551,7 +551,7 @@ impl Execution {
         if let Some(ref m) = self.manufacturer {
             Ok(m.to_owned())
         } else {
-            super::first_author(&manifest)
+            super::first_author(manifest)
         }
     }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -25,6 +25,8 @@ use std::io::{Read, Write};
 use std::path::Path;
 use std::process::Command;
 
+use toml::Value;
+
 pub const TARGET_NAME: &str = "target";
 
 // Cannot use dashes. WiX Toolset only allows A-Z, a-z, digits, underscores (_), or periods (.)
@@ -53,6 +55,33 @@ fn create_test_package_at_path(path: &Path, package_name: &str) {
         .status()
         .expect("Creation of test Cargo package");
     assert!(cargo_init_status.success());
+    let cargo_path = path.join("Cargo.toml");
+
+    let mut toml: Value = {
+        let mut cargo_toml_handle = File::open(&cargo_path).unwrap();
+        let mut cargo_toml_content = String::new();
+        cargo_toml_handle
+            .read_to_string(&mut cargo_toml_content)
+            .unwrap();
+        toml::from_str(&cargo_toml_content).unwrap()
+    };
+    {
+        toml.get_mut("package")
+            .map(|p| {
+                match p {
+                    Value::Table(ref mut t) => t.insert(
+                        String::from("authors"),
+                        Value::Array(vec![Value::from("author1"), Value::from("author2")]),
+                    ),
+                    _ => panic!("The 'package' section is not a table"),
+                };
+                Some(p)
+            })
+            .expect("A package section for the Cargo.toml");
+        let toml_string = toml.to_string();
+        let mut cargo_toml_handle = File::create(cargo_path).unwrap();
+        cargo_toml_handle.write_all(toml_string.as_bytes()).unwrap();
+    }
 }
 
 /// Create a new cargo project/package for a binary project in a temporary

--- a/tests/create.rs
+++ b/tests/create.rs
@@ -793,7 +793,7 @@ fn input_works_outside_cwd() {
         .unwrap();
     let result = run_with_package(
         Builder::default().input(package_manifest.path().to_str()),
-        &package.path(),
+        package.path(),
     );
     result.expect("OK result");
     package
@@ -1003,7 +1003,7 @@ fn workspace_package_works() {
         .build()
         .run()
         .unwrap();
-    let result = run(&mut Builder::default().package(Some(SUBPACKAGE1_NAME)));
+    let result = run(Builder::default().package(Some(SUBPACKAGE1_NAME)));
     env::set_current_dir(original_working_directory).unwrap();
     result.expect("OK result");
     package
@@ -1023,7 +1023,7 @@ fn cross_compilation_works() {
     let expected_msi_file = TARGET_WIX_DIR.join(format!("{}-0.1.0-x86_64.msi", PACKAGE_NAME));
     env::set_current_dir(package.path()).unwrap();
     initialize::Execution::default().run().unwrap();
-    let result = run(&mut Builder::default().target(Some("x86_64-pc-windows-msvc")));
+    let result = run(Builder::default().target(Some("x86_64-pc-windows-msvc")));
     env::set_current_dir(original_working_directory).unwrap();
     result.expect("OK result");
     package


### PR DESCRIPTION
This PR is split in three commits:
- adds authors to the generated cargo test files
- update the ci to use stable toolchain
- fix clippy for the stable toolchain

The ci with this pr has been tested here:
https://github.com/serpilliere/cargo-wix/actions/runs/2630611621
This PR has been created due to #165 
