### PR TITLE
Build only selected packages

### DIFF
--- a/src/create.rs
+++ b/src/create.rs
@@ -477,6 +477,9 @@ impl Execution {
             if self.target.is_some() {
                 builder.arg(format!("--target={}", target_triple));
             }
+            if let Some(ref package) = self.package {
+                builder.arg(format!("--package={}", package));
+            }
             builder.arg("--manifest-path").arg(&manifest_path);
             debug!("command = {:?}", builder);
             let status = builder.status()?;


### PR DESCRIPTION
This PR fixes the build process:
if the end users selects a sub package of a workspace, the current code build each sub packages.
This PR limits the compilation to the selected sub packages

Note:
I don't see here a way to generate a regression test, as it may test if other sub packages are not build (maybe test the resulting tar directory??).
Do you think it's mandatory here?
