### PR TITLE
Fix typo and clippy warnings

### DIFF
--- a/src/create.rs
+++ b/src/create.rs
@@ -1130,7 +1130,7 @@ impl Default for Execution {
 }
 
 /// The kind of WiX Object (wixobj) file.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum WixObjKind {
     /// A WiX Object (wixobj) file that ultimately links back to a WiX Source
     /// (wxs) file with a [`bundle`] tag.
@@ -1232,7 +1232,7 @@ impl TryFrom<&str> for WixObjKind {
 
 /// The kinds of installers that can be created using the WiX compiler
 /// (candle.exe) and linker (light.exe).
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum InstallerKind {
     /// An executable is used when an [Installation Package Bundle] is created.
     ///

--- a/src/eula.rs
+++ b/src/eula.rs
@@ -26,7 +26,7 @@ use std::str::FromStr;
 
 use cargo_metadata::Package;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Eula {
     CommandLine(PathBuf),
     Manifest(PathBuf),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -474,7 +474,7 @@ impl From<uuid::Error> for Error {
 ///
 /// These are also the valid values for the `-arch` option to the WiX compiler
 /// (candle.exe).
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum WixArch {
     /// The x86 32-bit architecture.
     X86,
@@ -529,7 +529,7 @@ impl FromStr for WixArch {
 }
 
 /// The aliases for the URLs to different Microsoft Authenticode timestamp servers.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TimestampServer {
     /// A URL to a timestamp server.
     Custom(String),
@@ -593,7 +593,7 @@ impl FromStr for TimestampServer {
 /// These are taken from the table in the [WixUI localization] documentation.
 ///
 /// [WixUI localization]: http://wixtoolset.org/documentation/manual/v3/wixui/wixui_localization.html
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Cultures {
     /// Arabic, Saudi Arabia
     ArSa,

--- a/src/templates/main.wxs.mustache
+++ b/src/templates/main.wxs.mustache
@@ -290,7 +290,7 @@
         {{/banner}}
         {{^banner}}
         <!--
-          Uncomment the next `WixVaraible` tag to customize the installer's
+          Uncomment the next `WixVariable` tag to customize the installer's
           Graphical User Interface (GUI) and add a custom banner image across
           the top of each screen. See the WiX Toolset documentation for details
           about customization.

--- a/src/templates/mod.rs
+++ b/src/templates/mod.rs
@@ -29,7 +29,7 @@ static GPL3_LICENSE_TEMPLATE: &str = include_str!("GPL-3.0.rtf.mustache");
 static MIT_LICENSE_TEMPLATE: &str = include_str!("MIT.rtf.mustache");
 
 /// The different templates that can be printed or written to a file.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Template {
     /// The [Apache-2.0] license.
     ///


### PR DESCRIPTION
I happened to notice a small typo in the default `main.wxs` file.