### PR TITLE
Added better error message for input argument

### DIFF
--- a/src/create.rs
+++ b/src/create.rs
@@ -603,7 +603,7 @@ impl Execution {
             .arg("-out")
             .arg(&installer_destination)
             .arg("-b")
-            .arg(&base_path);
+            .arg(base_path);
         if let Some(l) = locale {
             trace!("Using the a WiX localization file");
             linker.arg("-loc").arg(l);
@@ -960,7 +960,7 @@ impl Execution {
             Ok(t.to_owned())
         } else {
             let output = Command::new("rustc")
-                .args(&["--version", "--verbose"])
+                .args(["--version", "--verbose"])
                 .output()?;
             for line in output.stdout.split(|b| *b == b'\n') {
                 let mut line_elt = line.splitn(2, |b| *b == b':');


### PR DESCRIPTION
Related to #143.

Changes the error message to be more descriptive depending on the failure related to the `Cargo.toml` file.