### PR TITLE
Don't get deps when running cargo-metadata

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,6 +186,7 @@ fn manifest(input: Option<&PathBuf>) -> Result<Metadata> {
     let cargo_file_path = cargo_toml_file(input)?;
     debug!("cargo_file_path = {:?}", cargo_file_path);
     Ok(MetadataCommand::new()
+        .no_deps()
         .manifest_path(cargo_file_path)
         .exec()?)
 }


### PR DESCRIPTION
Cargo-metadata would take a long time due to downloading all the dependencies of the project. This is not actually necessary, since we only care about the metadata of the local packages in cargo-wix. By passing the --no-deps argument to cargo metadata, we avoid this behavior.