### PR TITLE
add --target-bin-dir to execute

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1623,6 +1623,12 @@ fn main() {
                         --release' is not executed.")
                     .long("no-build")
                     .action(ArgAction::SetTrue))
+                .arg(Arg::new("target-bin-dir")
+                    .help("A path to the directory of binaries to include in the installer")
+                    .long_help("Sets the CargoTargetBinDir variable that will be substituted \
+                        into main.wxs. Use in conjunction with --no-build to fully handle builds.")
+                    .long("target-bin-dir")
+                    .num_args(1))
                 .arg(Arg::new("no-capture")
                     .help("Displays all output from the builder, compiler, linker, and signer")
                     .long_help("By default, this subcommand captures, or hides, \
@@ -1945,6 +1951,7 @@ fn main() {
             create.locale(matches.get_one("locale").map(String::as_str));
             create.name(matches.get_one("name").map(String::as_str));
             create.no_build(matches.get_flag("no-build"));
+            create.target_bin_dir(matches.get_one("target-bin-dir").map(String::as_str));
             create.install(matches.get_flag("install"));
             create.output(matches.get_one("output").map(String::as_str));
             create.version(matches.get_one("install-version").map(String::as_str));

--- a/src/templates/main.wxs.mustache
+++ b/src/templates/main.wxs.mustache
@@ -26,20 +26,19 @@
                       installed.
   TargetVendor      = The rustc target vendor. This is typically "pc", but Rust
                       does support other vendors, like "uwp".
-  CargoTargetBinDir = The complete path to the binary (exe). The default would
-                      be "target\release\<BINARY_NAME>.exe" where
-                      "<BINARY_NAME>" is replaced with the name of each binary
-                      target defined in the package's manifest (Cargo.toml). If
-                      a different rustc target triple is used than the host,
-                      i.e. cross-compiling, then the default path would be
-                      "target\<CARGO_TARGET>\<CARGO_PROFILE>\<BINARY_NAME>.exe",
+  CargoTargetBinDir = The complete path to the directory containing the
+                      binaries (exes) to include. The default would be
+                      "target\release\". If an explicit rustc target triple is
+                      used, i.e. cross-compiling, then the default path would
+                      be "target\<CARGO_TARGET>\<CARGO_PROFILE>",
                       where "<CARGO_TARGET>" is replaced with the "CargoTarget"
                       variable value and "<CARGO_PROFILE>" is replaced with the
-                      value from the `CargoProfile` variable.
+                      value from the "CargoProfile" variable. This can also
+                      be overriden manually with tne "target-bin-dir" flag.
   CargoTargetDir    = The path to the directory for the build artifacts, i.e.
                       "target".
-  CargoProfile      = Either "debug" or `release` depending on the build
-                      profile. The default is "release".
+  CargoProfile      = The cargo profile used to build the binaries
+                      (usually "debug" or "release").
   Version           = The version for the installer. The default is the
                       "Major.Minor.Fix" semantic versioning number of the Rust
                       package.


### PR DESCRIPTION
This sets CargoTargetBinDir in the wix template, allowing something orchestrating cargo-wix to take the reigns on building/gathering binaries completely. Setting this an --no-build supresses the warning (as at this point there's a pretty clear signal the user is doing this intentionally and not as a temp thing).

No integration tests were added for this functionality because it wasn't clear to me how to reasonable test this, but the functionality is boring enough that it's easy to trust with just the unit tests.

As compensation some backlog tests/docs were added.

-----

Also does some cleanups to factor target-triple/profile logic so that things aren't recomputed in a bunch of places.

Also adds the arguably-forgotten-to-be-added package.metadata.wix.profile (for projects that always want to build with a special profile).

Note that --target-bin-dir this time is *intentionally* without a package.metadata pair, because it's pretty exceptional to want to fully bake the target dir.