### PR TITLE
fix: fix broken parsing in 'print' command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1865,7 +1865,11 @@ fn main() {
             init.build().run()
         }
         Some(("print", m)) => {
-            let template = m.get_one::<Template>("TEMPLATE").unwrap();
+            let template = m
+                .get_one::<String>("TEMPLATE")
+                .unwrap()
+                .parse::<Template>()
+                .unwrap();
             match template {
                 Template::Wxs => {
                     let mut print = print::wxs::Builder::new();
@@ -1896,7 +1900,7 @@ fn main() {
                     print.input(m.get_one("INPUT").map(String::as_str));
                     print.output(m.get_one("output").map(String::as_str));
                     print.package(m.get_one("package").map(String::as_str));
-                    print.build().run(t)
+                    print.build().run(&t)
                 }
             }
         }


### PR DESCRIPTION
I'm not sure how the old code was supposed to work but it would just crash trying to upcast something to Any inside clap. This approach still gets the expected validation but doesn't crash.