### PR TITLE
feat: clean up path handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,11 @@ name: CI
 on: [push, pull_request]
 jobs:
   test:
-    runs-on: windows-latest
     strategy:
       matrix:
         rust: [stable, 1.70.0]
+        os: [windows-latest, ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,6 +172,7 @@ name = "cargo-wix"
 version = "0.3.5"
 dependencies = [
  "assert_fs",
+ "camino",
  "cargo_metadata",
  "chrono",
  "clap 4.4.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ name = "cargo-wix"
 name = "wix"
 
 [dependencies]
+camino = "1"
 chrono = "0.4"
 clap = "4"
 encoding_rs_io = "0.1"

--- a/src/create.rs
+++ b/src/create.rs
@@ -2129,6 +2129,7 @@ mod tests {
         }
 
         #[test]
+        #[cfg(windows)]
         fn target_bin_dir_computation_works() {
             const EXPECTED: &str = "C:\\my-app\\target\\i686-pc-windows-msvc\\release";
             let mut builder = Builder::new();
@@ -2145,6 +2146,7 @@ mod tests {
         }
 
         #[test]
+        #[cfg(windows)]
         fn compiler_is_correct_with_defaults() {
             let expected = Command::new(
                 env::var_os(WIX_PATH_KEY)

--- a/src/eula.rs
+++ b/src/eula.rs
@@ -14,6 +14,8 @@
 
 use crate::Error;
 use crate::Result;
+use crate::StoredPath;
+use crate::StoredPathBuf;
 use crate::Template;
 use crate::LICENSE_FILE_NAME;
 use crate::RTF_FILE_EXTENSION;
@@ -21,37 +23,36 @@ use crate::RTF_FILE_EXTENSION;
 use log::{debug, trace};
 
 use std::fmt;
-use std::path::PathBuf;
 use std::str::FromStr;
 
 use cargo_metadata::Package;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Eula {
-    CommandLine(PathBuf),
-    Manifest(PathBuf),
+    CommandLine(StoredPathBuf),
+    Manifest(StoredPathBuf),
     Generate(Template),
     Disabled,
 }
 
 impl Eula {
-    pub fn new(p: Option<&PathBuf>, package: &Package) -> Result<Self> {
-        if let Some(ref path) = p {
-            Ok(Eula::CommandLine(path.into()))
+    pub fn new(p: Option<&StoredPath>, package: &Package) -> Result<Self> {
+        if let Some(path) = p {
+            Ok(Eula::CommandLine(path.to_owned()))
         } else {
             Eula::from_manifest(package)
         }
     }
 
     pub fn from_manifest(package: &Package) -> Result<Self> {
-        if let Some(license_file_path) = package.license_file().map(|p| p.into_std_path_buf()) {
+        if let Some(license_file_path) = package.license_file() {
             trace!("The 'license-file' field is specified in the package's manifest (Cargo.toml)");
             debug!("license_file_path = {:?}", license_file_path);
-            if license_file_path.extension().and_then(|s| s.to_str()) == Some(RTF_FILE_EXTENSION) {
+            if license_file_path.extension() == Some(RTF_FILE_EXTENSION) {
                 trace!(
                     "The '{}' path from the 'license-file' field in the package's \
                      manifest (Cargo.toml) has a RTF file extension.",
-                    license_file_path.display()
+                    license_file_path
                 );
                 if license_file_path.exists() {
                     trace!(
@@ -59,12 +60,14 @@ impl Eula {
                          manifest (Cargo.toml) exists and has a RTF file extension.",
                         license_file_path.exists()
                     );
-                    Ok(Eula::Manifest(license_file_path))
+                    Ok(Eula::Manifest(StoredPathBuf::from_utf8_path(
+                        &license_file_path,
+                    )))
                 } else {
                     Err(Error::Generic(format!(
                         "The '{}' file to be used for the EULA specified in the package's \
                          manifest (Cargo.toml) using the 'license-file' field does not exist.",
-                        license_file_path.display()
+                        license_file_path
                     )))
                 }
             } else {
@@ -72,7 +75,7 @@ impl Eula {
                     "The '{}' path from the 'license-file' field in the package's \
                      manifest (Cargo.toml) exists but it does not have a RTF file \
                      extension.",
-                    license_file_path.display()
+                    license_file_path
                 );
                 Ok(Eula::Disabled)
             }
@@ -104,8 +107,8 @@ impl Eula {
 impl fmt::Display for Eula {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Eula::CommandLine(ref path) => path.display().fmt(f),
-            Eula::Manifest(ref path) => path.display().fmt(f),
+            Eula::CommandLine(ref path) => path.fmt(f),
+            Eula::Manifest(ref path) => path.fmt(f),
             Eula::Generate(..) => write!(f, "{LICENSE_FILE_NAME}.{RTF_FILE_EXTENSION}"),
             Eula::Disabled => write!(f, "Disabled"),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,7 @@ pub mod purge;
 pub mod sign;
 mod templates;
 
+use camino::{Utf8Component, Utf8Path};
 use log::debug;
 
 use std::convert::TryFrom;
@@ -293,21 +294,21 @@ impl Error {
     ///
     /// ```rust
     /// use std::io;
-    /// use std::path::Path;
+    /// use camino::Utf8Path;
     /// use wix::Error;
     ///
-    /// let path = Path::new("C:\\");
+    /// let path = Utf8Path::new("C:\\");
     /// let expected = Error::Io(io::Error::new(
     ///     io::ErrorKind::AlreadyExists,
-    ///     path.display().to_string()
+    ///     path.to_string()
     /// ));
     /// assert_eq!(expected, Error::already_exists(path));
     /// ```
     ///
     /// [std::io::Error]: https://doc.rust-lang.org/std/io/struct.Error.html
     /// [std::io::ErrorKind::AlreadyExists]: https://doc.rust-lang.org/std/io/enum.ErrorKind.html
-    pub fn already_exists(p: &Path) -> Self {
-        io::Error::new(ErrorKind::AlreadyExists, p.display().to_string()).into()
+    pub fn already_exists(p: &Utf8Path) -> Self {
+        io::Error::new(ErrorKind::AlreadyExists, p.to_string()).into()
     }
 
     /// Creates a new `Error` from a [std::io::Error] with the
@@ -1034,6 +1035,213 @@ impl FromStr for Cultures {
         }
     }
 }
+/// A PathBuf that will be in the output of print (and therefore saved to disk)
+///
+/// A proper PathBuf should not be used for that, as we don't want to introduce
+/// platform-specific separators.
+///
+/// This type intentionally lacks some path functionality like `.exists()` because
+/// we don't want to be using it for *actual* path stuff, only for writing it to output.
+/// Most StoredPathBufs are just user-provided strings with no processing applied.
+///
+/// However sometimes we are forced to handle a PathBuf because of things like
+/// cargo-metadata, in which case [`StoredPathBuf::from_utf8_path`][] or
+/// [`StoredPathBuf::from_std_path`][] will convert the path to the windows path style.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct StoredPathBuf(String);
+
+/// A borrowed [`StoredPathBuf`][]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct StoredPath(str);
+
+impl StoredPathBuf {
+    /// Make a new StoredPathBuf from a String
+    pub fn new(v: String) -> Self {
+        Self(v)
+    }
+
+    /// Make a new StoredPath from a OS-specific path
+    ///
+    /// This breaks the path into its components and rewrites the slashes to `\`.
+    ///
+    /// Generally you should avoid this and just try to preserve the user input,
+    /// but it's required when using things like the output of cargo-metadata.
+    pub fn from_std_path(path: &Path) -> Option<Self> {
+        Utf8Path::from_path(path).map(Self::from_utf8_path)
+    }
+
+    /// Make a new StoredPath from a OS-specific Utf8Path
+    ///
+    /// This breaks the path into its components and rewrites the slashes to `\`.
+    ///
+    /// Generally you should avoid this and just try to preserve the user input,
+    /// but it's required when using things like the output of cargo-metadata.
+    ///
+    /// Also note that this does some handling of absolute paths, but that those
+    /// are kind of nonsensical to store longterm. Still, the user can hand them
+    /// to us, and we have to do our best to deal with it. Mostly this just comes
+    /// up in test code.
+    pub fn from_utf8_path(path: &Utf8Path) -> Self {
+        // The main quirk of this code is handling absolute paths.
+        // `C:\a\b\c` is given to us as `["C:", "\", "a", "b", "c"]`
+        let mut result = String::new();
+        let mut multipart = false;
+        for component in path.components() {
+            // Add separator for every part but the first,
+            // ignoring root prefixes like "C:\" and "/" which
+            // provide their own separators.
+            if multipart {
+                result.push('\\');
+            }
+            let part = match component {
+                // "C:"
+                Utf8Component::Prefix(prefix) => prefix.as_str(),
+                // the root slash
+                // (either the one at the end of "C:\" or the one at the start of "/a/b/c")
+                Utf8Component::RootDir => "\\",
+                other => {
+                    // Ok we're passed the weird root stuff, now should add seperators
+                    multipart = true;
+                    other.as_str()
+                }
+            };
+            result.push_str(part);
+        }
+        Self(result)
+    }
+}
+
+impl StoredPath {
+    /// Make a new StoredPath from a str
+    pub fn new(v: &str) -> &Self {
+        // SAFETY: this is the idiomatic pattern for converting between newtyped slices.
+        // See the impl of std::str::from_utf8_unchecked for an example.
+        unsafe { std::mem::transmute(v) }
+    }
+
+    /// Get the inner string
+    pub fn as_str(&self) -> &str {
+        self
+    }
+
+    /// Extracts the extension part of the [`self.file_name`][]
+    pub fn extension(&self) -> Option<&str> {
+        self.stem_and_extension().1
+    }
+
+    /// Extracts the stem (non-extension) part of the [`self.file_name`][].
+    pub fn file_stem(&self) -> Option<&str> {
+        self.stem_and_extension().0
+    }
+
+    // Implements `stem` and `extension` together based on the semantics defined by camino/std
+    fn stem_and_extension(&self) -> (Option<&str>, Option<&str>) {
+        let Some(name) = self.file_name() else {
+            // both: None if there's no file name
+            return (None, None);
+        };
+        if let Some((stem, extension)) = name.rsplit_once('.') {
+            if stem.is_empty() {
+                // stem: The entire file name if the file name begins with '.' and has no other '.'s within
+                // extension: None, if the file name begins with '.' and has no other '.'s within;
+                (Some(name), None)
+            } else {
+                // stem: Otherwise, the portion of the file name before the final '.'
+                // extension: Otherwise, the portion of the file name after the final '.'
+                (Some(stem), Some(extension))
+            }
+        } else {
+            // stem: The entire file name if there is no embedded '.'
+            // extension: None, if there is no embedded '.'
+            (Some(name), None)
+        }
+    }
+
+    /// Returns the final component of the path, if there is one.
+    pub fn file_name(&self) -> Option<&str> {
+        // Look for either path separator (windows file names shouldn't include either,
+        // so even though unix file names can have `\`, it won't work right on the actual
+        // platform that matters, so we can ignore that consideration.)
+        let name1 = self.rsplit_once('\\').map(|(_, name)| name);
+        let name2 = self.rsplit_once('/').map(|(_, name)| name);
+        match (name1, name2) {
+            (Some(name1), Some(name2)) => {
+                // Prefer whichever one came last
+                if name1.len() < name2.len() {
+                    Some(name1)
+                } else {
+                    Some(name2)
+                }
+            }
+            (Some(name), None) | (None, Some(name)) => Some(name),
+            (None, None) => None,
+        }
+    }
+}
+impl std::ops::Deref for StoredPathBuf {
+    type Target = StoredPath;
+    fn deref(&self) -> &Self::Target {
+        StoredPath::new(&self.0)
+    }
+}
+impl std::ops::Deref for StoredPath {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+impl std::borrow::Borrow<StoredPath> for StoredPathBuf {
+    fn borrow(&self) -> &StoredPath {
+        self
+    }
+}
+impl std::borrow::ToOwned for StoredPath {
+    type Owned = StoredPathBuf;
+
+    fn to_owned(&self) -> StoredPathBuf {
+        StoredPathBuf::new(self.0.to_owned())
+    }
+}
+impl std::convert::From<String> for StoredPathBuf {
+    fn from(v: String) -> Self {
+        Self::new(v)
+    }
+}
+impl std::convert::From<StoredPathBuf> for String {
+    fn from(v: StoredPathBuf) -> Self {
+        v.0
+    }
+}
+impl<'a> std::convert::From<&'a StoredPathBuf> for String {
+    fn from(v: &'a StoredPathBuf) -> Self {
+        v.0.clone()
+    }
+}
+impl<'a> std::convert::From<&'a str> for StoredPathBuf {
+    fn from(v: &'a str) -> Self {
+        StoredPath::new(v).to_owned()
+    }
+}
+impl std::fmt::Debug for StoredPath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        std::fmt::Debug::fmt(self.as_str(), f)
+    }
+}
+impl std::fmt::Display for StoredPath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        std::fmt::Display::fmt(self.as_str(), f)
+    }
+}
+impl std::fmt::Debug for StoredPathBuf {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        std::fmt::Debug::fmt(self.as_str(), f)
+    }
+}
+impl std::fmt::Display for StoredPathBuf {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        std::fmt::Display::fmt(self.as_str(), f)
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -1196,6 +1404,113 @@ mod tests {
         fn from_str_is_correct() {
             let arch = WixArch::from_str("thumbv7a-uwp-windows-msvc").unwrap();
             assert_eq!(arch, WixArch::Arm);
+        }
+    }
+
+    mod stored_path {
+        use crate::StoredPathBuf;
+        use camino::Utf8Path;
+
+        #[test]
+        fn absolute_windows_path_conversion() {
+            // Absolute native windows format
+            const INPUT: &str = "C:\\Users\\test\\AppData\\Local\\Temp\\.tmpMh0Mxg\\Example.tar.gz";
+            let path = StoredPathBuf::from_utf8_path(Utf8Path::new(INPUT));
+            assert_eq!(path.as_str(), INPUT);
+            assert_eq!(path.file_name(), Some("Example.tar.gz"));
+            assert_eq!(path.file_stem(), Some("Example.tar"));
+            assert_eq!(path.extension(), Some("gz"));
+        }
+
+        #[test]
+        fn verbatim_absolute_windows_path_conversion() {
+            // Absolute native windows format (verbatim style)
+            const INPUT: &str =
+                "\\\\?\\C:\\Users\\test\\AppData\\Local\\Temp\\.tmpMh0Mxg\\Example.tar.gz";
+            let path = StoredPathBuf::from_utf8_path(Utf8Path::new(INPUT));
+            assert_eq!(path.as_str(), INPUT);
+            assert_eq!(path.file_name(), Some("Example.tar.gz"));
+            assert_eq!(path.file_stem(), Some("Example.tar"));
+            assert_eq!(path.extension(), Some("gz"));
+        }
+
+        #[test]
+        fn relative_windows_path_conversion() {
+            // relative native windows format
+            const INPUT: &str = "resource\\Example.tar.gz";
+            let path = StoredPathBuf::from_utf8_path(Utf8Path::new(INPUT));
+            assert_eq!(path.as_str(), INPUT);
+            assert_eq!(path.file_name(), Some("Example.tar.gz"));
+            assert_eq!(path.file_stem(), Some("Example.tar"));
+            assert_eq!(path.extension(), Some("gz"));
+        }
+
+        #[test]
+        fn absolute_unix_path_conversion() {
+            // absolute native unix format
+            const INPUT: &str = "/users/home/test/Example.tar.gz";
+            let path = StoredPathBuf::from_utf8_path(Utf8Path::new(INPUT));
+            assert_eq!(path.as_str(), "\\users\\home\\test\\Example.tar.gz");
+            assert_eq!(path.file_name(), Some("Example.tar.gz"));
+            assert_eq!(path.file_stem(), Some("Example.tar"));
+            assert_eq!(path.extension(), Some("gz"));
+        }
+
+        #[test]
+        fn relative_unix_path_conversion() {
+            // relative native unix format
+            const INPUT: &str = "resource/Example.tar.gz";
+            let path = StoredPathBuf::from_utf8_path(Utf8Path::new(INPUT));
+            assert_eq!(path.as_str(), "resource\\Example.tar.gz");
+            assert_eq!(path.file_name(), Some("Example.tar.gz"));
+            assert_eq!(path.file_stem(), Some("Example.tar"));
+            assert_eq!(path.extension(), Some("gz"));
+        }
+
+        #[test]
+        fn mixed_path_conversion1() {
+            // a mix of both formats (natural when combining user input with OS input)
+            const INPUT: &str = "resource/blah\\Example.tar.gz";
+            let path = StoredPathBuf::from_utf8_path(Utf8Path::new(INPUT));
+            assert_eq!(path.as_str(), "resource\\blah\\Example.tar.gz");
+            assert_eq!(path.file_name(), Some("Example.tar.gz"));
+            assert_eq!(path.file_stem(), Some("Example.tar"));
+            assert_eq!(path.extension(), Some("gz"));
+        }
+
+        #[test]
+        fn mixed_path_conversion2() {
+            // a mix of both formats (natural when combining user input with OS input)
+            const INPUT: &str = "resource\\blah/Example.tar.gz";
+            let path = StoredPathBuf::from_utf8_path(Utf8Path::new(INPUT));
+            assert_eq!(path.as_str(), "resource\\blah\\Example.tar.gz");
+            assert_eq!(path.file_name(), Some("Example.tar.gz"));
+            assert_eq!(path.file_stem(), Some("Example.tar"));
+            assert_eq!(path.extension(), Some("gz"));
+        }
+
+        #[test]
+        fn mixed_path_unconverted1() {
+            // a mix of both formats (natural when combining user input with OS input)
+            // here we're testing the verbatim `new` conversion produces a coherent value
+            const INPUT: &str = "resource\\blah/Example.tar.gz";
+            let path = StoredPathBuf::new(INPUT.to_owned());
+            assert_eq!(path.as_str(), "resource\\blah/Example.tar.gz");
+            assert_eq!(path.file_name(), Some("Example.tar.gz"));
+            assert_eq!(path.file_stem(), Some("Example.tar"));
+            assert_eq!(path.extension(), Some("gz"));
+        }
+
+        #[test]
+        fn mixed_path_unconverted2() {
+            // a mix of both formats (natural when combining user input with OS input)
+            // here we're testing the verbatim `new` conversion produces a coherent value
+            const INPUT: &str = "resource/blah\\Example.tar.gz";
+            let path = StoredPathBuf::new(INPUT.to_owned());
+            assert_eq!(path.as_str(), "resource/blah\\Example.tar.gz");
+            assert_eq!(path.file_name(), Some("Example.tar.gz"));
+            assert_eq!(path.file_stem(), Some("Example.tar"));
+            assert_eq!(path.extension(), Some("gz"));
         }
     }
 }

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -489,6 +489,7 @@ mod tests {
         }
 
         #[test]
+        #[cfg(windows)]
         fn signer_works() {
             let result = Execution::default().signer();
             assert!(result.is_ok());

--- a/tests/create.rs
+++ b/tests/create.rs
@@ -1,3 +1,5 @@
+#![cfg(windows)]
+
 // Copyright (C) 2017 Christopher R. Field.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/initialize.rs
+++ b/tests/initialize.rs
@@ -32,8 +32,8 @@ use toml::{Table, Value};
 
 use wix::initialize::{Builder, Execution};
 use wix::{
-    CARGO_MANIFEST_FILE, LICENSE_FILE_NAME, RTF_FILE_EXTENSION, WIX, WIX_SOURCE_FILE_EXTENSION,
-    WIX_SOURCE_FILE_NAME,
+    StoredPathBuf, CARGO_MANIFEST_FILE, LICENSE_FILE_NAME, RTF_FILE_EXTENSION, WIX,
+    WIX_SOURCE_FILE_EXTENSION, WIX_SOURCE_FILE_NAME,
 };
 
 use crate::common::{add_license_to_package, init_logging, SUBPACKAGE1_NAME, SUBPACKAGE2_NAME};
@@ -414,14 +414,18 @@ fn mit_license_id_works() {
             package.child(MAIN_WXS_PATH.as_path()).path(),
             "//*/wix:File[@Id='LicenseFile']/@Source"
         ),
-        LICENSE_RTF_PATH.display().to_string()
+        StoredPathBuf::from_std_path(LICENSE_RTF_PATH.as_path())
+            .unwrap()
+            .to_string()
     );
     assert_eq!(
         common::evaluate_xpath(
             package.child(MAIN_WXS_PATH.as_path()).path(),
             "//*/wix:WixVariable[@Id='WixUILicenseRtf']/@Value"
         ),
-        LICENSE_RTF_PATH.display().to_string()
+        StoredPathBuf::from_std_path(LICENSE_RTF_PATH.as_path())
+            .unwrap()
+            .to_string()
     );
 }
 
@@ -480,14 +484,18 @@ fn apache2_license_id_works() {
             package.child(MAIN_WXS_PATH.as_path()).path(),
             "//*/wix:File[@Id='LicenseFile']/@Source"
         ),
-        LICENSE_RTF_PATH.display().to_string()
+        StoredPathBuf::from_std_path(LICENSE_RTF_PATH.as_path())
+            .unwrap()
+            .to_string()
     );
     assert_eq!(
         common::evaluate_xpath(
             package.child(MAIN_WXS_PATH.as_path()).path(),
             "//*/wix:WixVariable[@Id='WixUILicenseRtf']/@Value"
         ),
-        LICENSE_RTF_PATH.display().to_string()
+        StoredPathBuf::from_std_path(LICENSE_RTF_PATH.as_path())
+            .unwrap()
+            .to_string()
     );
 }
 
@@ -546,14 +554,18 @@ fn gpl3_license_id_works() {
             package.child(MAIN_WXS_PATH.as_path()).path(),
             "//*/wix:File[@Id='LicenseFile']/@Source"
         ),
-        LICENSE_RTF_PATH.display().to_string()
+        StoredPathBuf::from_std_path(LICENSE_RTF_PATH.as_path())
+            .unwrap()
+            .to_string()
     );
     assert_eq!(
         common::evaluate_xpath(
             package.child(MAIN_WXS_PATH.as_path()).path(),
             "//*/wix:WixVariable[@Id='WixUILicenseRtf']/@Value"
         ),
-        LICENSE_RTF_PATH.display().to_string()
+        StoredPathBuf::from_std_path(LICENSE_RTF_PATH.as_path())
+            .unwrap()
+            .to_string()
     );
 }
 
@@ -607,14 +619,18 @@ fn license_file_field_with_rtf_file_works() {
             package.child(MAIN_WXS_PATH.as_path()).path(),
             "//*/wix:File[@Id='LicenseFile']/@Source"
         ),
-        package_license.path().to_str().unwrap()
+        StoredPathBuf::from_std_path(package_license.path())
+            .unwrap()
+            .to_string()
     );
     assert_eq!(
         common::evaluate_xpath(
             package.child(MAIN_WXS_PATH.as_path()).path(),
             "//*/wix:WixVariable[@Id='WixUILicenseRtf']/@Value"
         ),
-        package_license.path().to_str().unwrap()
+        StoredPathBuf::from_std_path(package_license.path())
+            .unwrap()
+            .to_string()
     );
 }
 
@@ -668,7 +684,9 @@ fn license_file_field_with_txt_file_works() {
             package.child(MAIN_WXS_PATH.as_path()).path(),
             "//*/wix:File[@Id='LicenseFile']/@Source"
         ),
-        package_license.path().to_str().unwrap()
+        StoredPathBuf::from_std_path(package_license.path())
+            .unwrap()
+            .to_string()
     );
 }
 


### PR DESCRIPTION
* Depend on camino to avoid needless conversions of the camino paths cargo_metadata gives us
* Add a StoredPath(Buf) type that is for paths that will get written to output files like main.wxs
  * Most interesting part is StoredPathBuf::from_utf8_path
* Clean up code to use new path types more