### PR TITLE
Fixed clippy warnings and CI errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,15 @@
 name: CI
-on: [push, pull_request]
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+  workflow_dispatch:
+
 jobs:
   test:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        rust: [stable, 1.70.0]
+        rust: [stable, 1.74.0]
         os: [windows-latest, ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        rust: [stable, 1.74.0]
+        rust: [stable, 1.78.0]
         os: [windows-latest, ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://github.com/volks73/cargo-wix"
 readme = "README.md"
 edition = "2021"
 exclude = ["/.github"]
-rust-version = "1.74.0"
+rust-version = "1.78.0"
 
 [[bin]]
 name = "cargo-wix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://github.com/volks73/cargo-wix"
 readme = "README.md"
 edition = "2021"
 exclude = ["/.github"]
-rust-version = "1.70.0"
+rust-version = "1.74.0"
 
 [[bin]]
 name = "cargo-wix"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A subcommand for [Cargo](http://doc.crates.io/) that builds a Windows installer 
 [![Crates.io](https://img.shields.io/crates/v/cargo-wix.svg)](https://crates.io/crates/cargo-wix)
 [![GitHub release](https://img.shields.io/github/release/volks73/cargo-wix.svg)](https://github.com/volks73/cargo-wix/releases)
 [![Crates.io](https://img.shields.io/crates/l/cargo-wix.svg)](https://github.com/volks73/cargo-wix#license)
-[![Build Status](https://github.com/volks73/cargo-wix/workflows/CI/badge.svg?branch=main)](https://github.com/volks73/cargo-wix/actions?query=branch%3Amain)
+[![Build Status](https://github.com/volks73/cargo-wix/actions/workflows/ci.yml/badge.svg)](https://github.com/volks73/cargo-wix/actions/workflows/ci.yml)
 
 ## Quick Start
 

--- a/src/clean.rs
+++ b/src/clean.rs
@@ -54,7 +54,7 @@ impl<'a> Builder<'a> {
     }
 }
 
-impl<'a> Default for Builder<'a> {
+impl Default for Builder<'_> {
     fn default() -> Self {
         Builder::new()
     }

--- a/src/create.rs
+++ b/src/create.rs
@@ -992,15 +992,13 @@ impl Execution {
     fn no_build(&self, metadata: &Value) -> bool {
         if self.no_build {
             true
-        } else if let Some(pkg_meta_wix_no_build) = metadata
-            .get("wix")
-            .and_then(|w| w.as_object())
-            .and_then(|t| t.get("no-build"))
-            .and_then(|c| c.as_bool())
-        {
-            pkg_meta_wix_no_build
         } else {
-            false
+            metadata
+                .get("wix")
+                .and_then(|w| w.as_object())
+                .and_then(|t| t.get("no-build"))
+                .and_then(|c| c.as_bool())
+                .unwrap_or(false)
         }
     }
 

--- a/src/create.rs
+++ b/src/create.rs
@@ -777,15 +777,13 @@ impl Execution {
     fn debug_name(&self, metadata: &Value) -> bool {
         if self.debug_name {
             true
-        } else if let Some(pkg_meta_wix_debug_name) = metadata
-            .get("wix")
-            .and_then(|w| w.as_object())
-            .and_then(|t| t.get("dbg-name"))
-            .and_then(|c| c.as_bool())
-        {
-            pkg_meta_wix_debug_name
         } else {
-            false
+            metadata
+                .get("wix")
+                .and_then(|w| w.as_object())
+                .and_then(|t| t.get("dbg-name"))
+                .and_then(|c| c.as_bool())
+                .unwrap_or(false)
         }
     }
 

--- a/src/create.rs
+++ b/src/create.rs
@@ -529,7 +529,7 @@ impl Execution {
         }
         compiler
             .arg("-arch")
-            .arg(&wix_arch.to_string())
+            .arg(wix_arch.to_string())
             .arg("-ext")
             .arg("WixUtilExtension");
         if let Some(vendor) = &cfg.target_vendor {

--- a/src/create.rs
+++ b/src/create.rs
@@ -386,7 +386,7 @@ impl<'a> Builder<'a> {
     }
 }
 
-impl<'a> Default for Builder<'a> {
+impl Default for Builder<'_> {
     fn default() -> Self {
         Builder::new()
     }

--- a/src/create.rs
+++ b/src/create.rs
@@ -764,15 +764,13 @@ impl Execution {
     fn debug_build(&self, metadata: &Value) -> bool {
         if self.debug_build {
             true
-        } else if let Some(pkg_meta_wix_debug_build) = metadata
-            .get("wix")
-            .and_then(|w| w.as_object())
-            .and_then(|t| t.get("dbg-build"))
-            .and_then(|c| c.as_bool())
-        {
-            pkg_meta_wix_debug_build
         } else {
-            false
+            metadata
+                .get("wix")
+                .and_then(|w| w.as_object())
+                .and_then(|t| t.get("dbg-build"))
+                .and_then(|c| c.as_bool())
+                .unwrap_or(false)
         }
     }
 

--- a/src/initialize.rs
+++ b/src/initialize.rs
@@ -394,7 +394,7 @@ impl<'a> Builder<'a> {
     }
 }
 
-impl<'a> Default for Builder<'a> {
+impl Default for Builder<'_> {
     fn default() -> Self {
         Builder::new()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -491,7 +491,7 @@ impl PartialEq for Error {
     }
 }
 
-impl<'a> From<&'a str> for Error {
+impl From<&str> for Error {
     fn from(s: &str) -> Self {
         Error::Generic(s.to_string())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -434,32 +434,32 @@
 //! - `TargetTriple` = The rustc target triple name as seen with the `rustc
 //!   --print target-list` command
 //! - `TargetEnv` = The rustc target environment, as seen with the output from
-//! the `rustc --print cfg` command as `target_env`. On Windows, this typically
-//! either `msvc` or `gnu` depending on the toolchain downloaded and installed.
+//!   the `rustc --print cfg` command as `target_env`. On Windows, this typically
+//!   either `msvc` or `gnu` depending on the toolchain downloaded and installed.
 //! - `TargetVendor` = The rustc target vendor, as seen with the output from the
-//! `rustc --print cfg` command as `target_vendor`. This is typically `pc`, but Rust
-//! does support other vendors, like `uwp`.
+//!   `rustc --print cfg` command as `target_vendor`. This is typically `pc`, but Rust
+//!   does support other vendors, like `uwp`.
 //! - `CargoTargetBinDir` = The complete path to the binary (exe). The default
-//! would be `target\release\<BINARY_NAME>.exe` where `<BINARY_NAME>` is replaced
-//! with the name of each binary target defined in the package's manifest
-//! (Cargo.toml). If a different rustc target triple is used than the host, i.e.
-//! cross-compiling, then the default path would be
-//! `target\<CARGO_TARGET>\<CARGO_PROFILE>\<BINARY_NAME>.exe`, where
-//! `<CARGO_TARGET>` is replaced with the `CargoTarget` variable value and
-//! `<CARGO_PROFILE>` is replaced with the value from the `CargoProfile` variable.
+//!   would be `target\release\<BINARY_NAME>.exe` where `<BINARY_NAME>` is replaced
+//!   with the name of each binary target defined in the package's manifest
+//!   (Cargo.toml). If a different rustc target triple is used than the host, i.e.
+//!   cross-compiling, then the default path would be
+//!   `target\<CARGO_TARGET>\<CARGO_PROFILE>\<BINARY_NAME>.exe`, where
+//!   `<CARGO_TARGET>` is replaced with the `CargoTarget` variable value and
+//!   `<CARGO_PROFILE>` is replaced with the value from the `CargoProfile` variable.
 //! - `CargoTargetDir` = The path to the directory for the build artifacts, i.e.
-//! `target`.
+//!   `target`.
 //! - `CargoProfile` = Either `debug` or `release` depending on the build
-//! profile. The default is `release`.
+//!   profile. The default is `release`.
 //! - `Platform` = (Deprecated) Either `x86`, `x64`, `arm`, or `arm64`. See the
-//! documentation for the WiX Toolset compiler (candle.exe) `-arch` option.
-//! Note, this variable is deprecated and will eventually be removed because it is
-//! ultimately redundant to the `$(sys.BUILDARCH)` variable that is already provided
-//! by the WiX Toolset compiler. Existing projects should replace usage of
-//! `$(var.Platform)` with `$(sys.BUILDARCH)`. No action is needed for new projects.
+//!   documentation for the WiX Toolset compiler (candle.exe) `-arch` option.
+//!   Note, this variable is deprecated and will eventually be removed because it is
+//!   ultimately redundant to the `$(sys.BUILDARCH)` variable that is already provided
+//!   by the WiX Toolset compiler. Existing projects should replace usage of
+//!   `$(var.Platform)` with `$(sys.BUILDARCH)`. No action is needed for new projects.
 //! - `Profile` = (Deprecated) See `CargoProfile`.
 //! - `Version` = The version for the installer. The default is the
-//! `Major.Minor.Fix` semantic versioning number of the Rust package.
+//!   `Major.Minor.Fix` semantic versioning number of the Rust package.
 //!
 //! Additional, user-defined variables for custom WXS files can be passed to the
 //! WiX Toolset compiler (candle.exe) using the cargo-wix subcommand

--- a/src/print/license.rs
+++ b/src/print/license.rs
@@ -117,7 +117,7 @@ impl<'a> Builder<'a> {
     }
 }
 
-impl<'a> Default for Builder<'a> {
+impl Default for Builder<'_> {
     fn default() -> Self {
         Builder::new()
     }

--- a/src/print/license.rs
+++ b/src/print/license.rs
@@ -172,7 +172,6 @@ impl Execution {
     fn copyright_year(&self) -> String {
         self.copyright_year
             .clone()
-            .map(String::from)
             .unwrap_or_else(|| Utc::now().year().to_string())
     }
 }

--- a/src/print/wxs.rs
+++ b/src/print/wxs.rs
@@ -354,7 +354,7 @@ impl<'a> Builder<'a> {
     }
 }
 
-impl<'a> Default for Builder<'a> {
+impl Default for Builder<'_> {
     fn default() -> Self {
         Builder::new()
     }

--- a/src/purge.rs
+++ b/src/purge.rs
@@ -59,7 +59,7 @@ impl<'a> Builder<'a> {
     }
 }
 
-impl<'a> Default for Builder<'a> {
+impl Default for Builder<'_> {
     fn default() -> Self {
         Builder::new()
     }

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -159,7 +159,7 @@ impl<'a> Builder<'a> {
     }
 }
 
-impl<'a> Default for Builder<'a> {
+impl Default for Builder<'_> {
     fn default() -> Self {
         Builder::new()
     }


### PR DESCRIPTION
Fixes the clippy warnings and bumps the Rust version from v1.70.0 to v1.74.0 to fix errors with the CI build and dependencies needing a newer version of Rust.